### PR TITLE
Move docker images to daskgateway org

### DIFF
--- a/continuous_integration/docker/hadoop/Dockerfile
+++ b/continuous_integration/docker/hadoop/Dockerfile
@@ -1,4 +1,4 @@
-FROM jcrist/dask-gateway-testing-base:latest
+FROM daskgateway/testing-base:latest
 MAINTAINER jcrist
 
 # Install common utilities

--- a/continuous_integration/docker/hadoop/start.sh
+++ b/continuous_integration/docker/hadoop/start.sh
@@ -10,4 +10,4 @@ docker run --rm -d \
     -h master.example.com \
     -v "$git_root":/working \
     -p 8088:8088 \
-    jcrist/dask-gateway-testing-hadoop
+    daskgateway/testing-hadoop

--- a/continuous_integration/docker/pbs/Dockerfile
+++ b/continuous_integration/docker/pbs/Dockerfile
@@ -1,4 +1,4 @@
-FROM jcrist/dask-gateway-testing-base:latest
+FROM daskgateway/testing-base:latest
 
 # Install pbspro
 RUN yum install -y unzip \

--- a/continuous_integration/docker/pbs/start.sh
+++ b/continuous_integration/docker/pbs/start.sh
@@ -11,4 +11,4 @@ docker run --rm -d \
     -v "$git_root":/working \
     -p 8088:8088 \
     --cap-add=SYS_RESOURCE \
-    jcrist/dask-gateway-testing-pbs
+    daskgateway/testing-pbs

--- a/continuous_integration/docker/slurm/Dockerfile
+++ b/continuous_integration/docker/slurm/Dockerfile
@@ -1,4 +1,4 @@
-FROM jcrist/dask-gateway-testing-base:latest
+FROM daskgateway/testing-base:latest
 
 # Build and install slurm
 RUN yum install -y epel-release \

--- a/continuous_integration/docker/slurm/start.sh
+++ b/continuous_integration/docker/slurm/start.sh
@@ -9,4 +9,4 @@ docker run --rm -d \
     --name slurm \
     -h slurm \
     -v "$git_root":/working \
-    jcrist/dask-gateway-testing-slurm
+    daskgateway/testing-slurm

--- a/continuous_integration/kubernetes/docker/dask-gateway/Dockerfile
+++ b/continuous_integration/kubernetes/docker/dask-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM jcrist/dask-gateway:latest
+FROM daskgateway/dask-gateway:latest
 
 # Install dask-gateway
 COPY ./dask-gateway /gateway-source

--- a/continuous_integration/kubernetes/install.sh
+++ b/continuous_integration/kubernetes/install.sh
@@ -25,5 +25,5 @@ if [[ "$TRAVIS" != "true" ]]; then
     eval $(minikube docker-env)
 fi
 pushd $git_root
-docker build -t jcrist/dask-gateway -f continuous_integration/kubernetes/docker/dask-gateway/Dockerfile .
+docker build -t daskgateway/dask-gateway -f continuous_integration/kubernetes/docker/dask-gateway/Dockerfile .
 popd

--- a/continuous_integration/kubernetes/start.sh
+++ b/continuous_integration/kubernetes/start.sh
@@ -91,7 +91,7 @@ spec:
   serviceAccountName: gateway
   containers:
     - name: dask-gateway-tests
-      image: jcrist/dask-gateway-base:latest
+      image: daskgateway/dask-gateway-base:latest
       args: 
         - sleep
         - infinity

--- a/dask-gateway-server/dask_gateway_server/managers/kubernetes.py
+++ b/dask-gateway-server/dask_gateway_server/managers/kubernetes.py
@@ -258,7 +258,7 @@ class KubeClusterManager(ClusterManager):
         return "default"
 
     image = Unicode(
-        "jcrist/dask-gateway:latest",
+        "daskgateway/dask-gateway:latest",
         help="Docker image to use for running user's containers.",
         config=True,
     )

--- a/demo/Dockerfile
+++ b/demo/Dockerfile
@@ -1,4 +1,4 @@
-FROM jcrist/dask-gateway-testing-hadoop:latest
+FROM daskgateway/testing-hadoop:latest
 MAINTAINER jcrist
 
 # Copy over files

--- a/demo/start-demo.sh
+++ b/demo/start-demo.sh
@@ -12,4 +12,4 @@ docker run -d --rm \
     -p 8787:8787 \
     -p 8786:8786 \
     -p 8088:8088 \
-    jcrist/dask-gateway-demo-hadoop
+    daskgateway/demo-hadoop

--- a/resources/helm/dask-gateway/values.yaml
+++ b/resources/helm/dask-gateway/values.yaml
@@ -17,7 +17,7 @@ gateway:
   resources: {}
 
   image:
-    name: jcrist/dask-gateway-server
+    name: daskgateway/dask-gateway-server
     tag: 0.3.0
     pullPolicy: IfNotPresent
 
@@ -39,7 +39,7 @@ gateway:
     workerStartTimeout: null
 
     image:
-      name: jcrist/dask-gateway
+      name: daskgateway/dask-gateway
       tag: 0.3.0
       pullPolicy: IfNotPresent
 
@@ -73,7 +73,7 @@ schedulerProxy:
   resources: {}
 
   image:
-    name: jcrist/dask-gateway-server
+    name: daskgateway/dask-gateway-server
     tag: 0.3.0
     pullPolicy: IfNotPresent
 
@@ -89,7 +89,7 @@ webProxy:
   resources: {}
 
   image:
-    name: jcrist/dask-gateway-server
+    name: daskgateway/dask-gateway-server
     tag: 0.3.0
     pullPolicy: IfNotPresent
 

--- a/resources/helm/images/README.rst
+++ b/resources/helm/images/README.rst
@@ -3,14 +3,14 @@ Docker Images
 
 Dask-Gateway provides the following docker images:
 
-- ``jcrist/dask-gateway-base``
+- ``daskgateway/dask-gateway-base``
 
   A base image containing conda and other base requirements.
 
-- ``jcrist/dask-gateway``
+- ``daskgateway/dask-gateway``
 
   An image for running Dask Gateway Scheduler/Worker processes.
 
-- ``jcrist/dask-gateway-server``
+- ``daskgateway/dask-gateway-server``
 
   An image for running the Dask Gateway server.

--- a/resources/helm/images/dask-gateway-server/Dockerfile
+++ b/resources/helm/images/dask-gateway-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM jcrist/dask-gateway-base
+FROM daskgateway/dask-gateway-base
 LABEL MAINTAINER="Jim Crist"
 
 # Install dask-gateway

--- a/resources/helm/images/dask-gateway/Dockerfile
+++ b/resources/helm/images/dask-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM jcrist/dask-gateway-base
+FROM daskgateway/dask-gateway-base
 LABEL MAINTAINER="Jim Crist"
 
 # Does the following in one layer


### PR DESCRIPTION
We moved our docker images out of `jcrist` and into the `daskgateway`
org. Updating image names appropriately.

Fixes #104.