### PR TITLE
Update Helm Chart

### DIFF
--- a/resources/helm/dask-gateway/templates/configmap.yaml
+++ b/resources/helm/dask-gateway/templates/configmap.yaml
@@ -31,29 +31,32 @@ data:
         return value
 
     # Extract address information about the other services
-    if os.environ.get("DASK_GATEWAY_PROXY_CONTAINER", False):
-        scheduler_proxy_public = "tls://0.0.0.0:8786"
-        scheduler_proxy_api = "tls://0.0.0.0:8001"
-        web_proxy_public = "http://0.0.0.0:8000"
-        web_proxy_api = "http://0.0.0.0:8001"
-    else:
-        def _make_addr(scheme, name):
-            name = os.environ[name].replace("-", "_").upper()
-            host = os.environ[name + "_SERVICE_HOST"]
-            port = int(os.environ[name + "_SERVICE_PORT"])
-            return "%s://%s:%d" % (scheme, host, port)
+    def _make_addr(scheme, name):
+        name = os.environ[name].replace("-", "_").upper()
+        host = os.environ[name + "_SERVICE_HOST"]
+        port = int(os.environ[name + "_SERVICE_PORT"])
+        return "%s://%s:%d" % (scheme, host, port)
 
-        scheduler_proxy_public = _make_addr("tls", "SCHEDULER_PROXY_PUBLIC_SERVICE_NAME")
-        scheduler_proxy_api = _make_addr("http", "SCHEDULER_PROXY_API_SERVICE_NAME")
+    if "GATEWAY_API_SERVICE_NAME" in os.environ:
+        gateway_api = _make_addr("http", "GATEWAY_API_SERVICE_NAME")
         web_proxy_public = _make_addr("http", "WEB_PROXY_PUBLIC_SERVICE_NAME")
         web_proxy_api = _make_addr("http", "WEB_PROXY_API_SERVICE_NAME")
+        scheduler_proxy_public = _make_addr("tls", "SCHEDULER_PROXY_PUBLIC_SERVICE_NAME")
+        scheduler_proxy_api = _make_addr("http", "SCHEDULER_PROXY_API_SERVICE_NAME")
+
+        c.DaskGateway.private_connect_url = gateway_api
+        c.DaskGateway.public_connect_url = web_proxy_public
+        c.DaskGateway.gateway_url = scheduler_proxy_public
+        c.WebProxy.api_connect_url = web_proxy_api
+        c.SchedulerProxy.api_connect_url = scheduler_proxy_api
+    else:
+        c.DaskGateway.gateway_url = "tls://0.0.0.0:8786"
 
     # Configure the various addresses
+    c.DaskGateway.public_url = "http://0.0.0.0:8000"
     c.DaskGateway.private_url = "http://0.0.0.0:8001"
-    c.DaskGateway.public_url = web_proxy_public
-    c.DaskGateway.gateway_url = scheduler_proxy_public
-    c.WebProxy.api_url = web_proxy_api
-    c.SchedulerProxy.api_url = scheduler_proxy_api
+    c.SchedulerProxy.api_url = "http://0.0.0.0:8001"
+    c.WebProxy.api_url = "http://0.0.0.0:8001"
 
     # Proxies aren't managed by the gateway
     c.SchedulerProxy.externally_managed = True

--- a/resources/helm/dask-gateway/templates/gateway-deployment.yaml
+++ b/resources/helm/dask-gateway/templates/gateway-deployment.yaml
@@ -60,6 +60,8 @@ spec:
                   name: {{ include "dask-gateway.fullname" . }}
                   key: jupyterhub-api-token
             {{- end }}
+            - name: GATEWAY_API_SERVICE_NAME
+              value: {{ include "dask-gateway.fullname" . | printf "gateway-api-%s" | trunc 63 | trimSuffix "-" }}
             - name: SCHEDULER_PROXY_PUBLIC_SERVICE_NAME
               value: {{ include "dask-gateway.fullname" . | printf "scheduler-public-%s" | trunc 63 | trimSuffix "-" }}
             - name: SCHEDULER_PROXY_API_SERVICE_NAME

--- a/resources/helm/dask-gateway/templates/gateway-service.yaml
+++ b/resources/helm/dask-gateway/templates/gateway-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "dask-gateway.fullname" . | printf "gateway-api-%s" | trunc 63 | trimSuffix "-" }}
+  labels:
+    {{- include "dask-gateway.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway-api
+spec:
+  selector:
+    {{- include "dask-gateway.labels" . | nindent 4 }}
+    app.kubernetes.io/component: gateway
+  ports:
+    - protocol: TCP
+      port: 8001
+      targetPort: 8001

--- a/resources/helm/dask-gateway/templates/scheduler-proxy-deployment.yaml
+++ b/resources/helm/dask-gateway/templates/scheduler-proxy-deployment.yaml
@@ -44,8 +44,6 @@ spec:
                 secretKeyRef:
                   name: {{ include "dask-gateway.fullname" . }}
                   key: proxy-token
-            - name: DASK_GATEWAY_PROXY_CONTAINER
-              value: "true"
           ports:
             - containerPort: 8001
               name: api

--- a/resources/helm/dask-gateway/templates/web-proxy-deployment.yaml
+++ b/resources/helm/dask-gateway/templates/web-proxy-deployment.yaml
@@ -44,8 +44,6 @@ spec:
                 secretKeyRef:
                   name: {{ include "dask-gateway.fullname" . }}
                   key: proxy-token
-            - name: DASK_GATEWAY_PROXY_CONTAINER
-              value: "true"
           ports:
             - containerPort: 8001
               name: api

--- a/resources/helm/testing/build-image-client.sh
+++ b/resources/helm/testing/build-image-client.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e
+
+this_dir="$(dirname "${BASH_SOURCE[0]}")"
+full_path_this_dir="$(cd "${this_dir}" && pwd)"
+git_root="$(cd "${full_path_this_dir}/../../.." && pwd)"
+
+echo "Building scheduler/worker test image"
+if [[ "$TRAVIS" != "true" ]]; then
+    eval $(minikube docker-env)
+fi
+
+pushd $git_root
+docker build -t dask-gateway-test -f resources/helm/testing/images/dask-gateway/Dockerfile .
+popd

--- a/resources/helm/testing/build-image-server.sh
+++ b/resources/helm/testing/build-image-server.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -e
+
+this_dir="$(dirname "${BASH_SOURCE[0]}")"
+full_path_this_dir="$(cd "${this_dir}" && pwd)"
+git_root="$(cd "${full_path_this_dir}/../../.." && pwd)"
+
+echo "Building server test image"
+if [[ "$TRAVIS" != "true" ]]; then
+    eval $(minikube docker-env)
+fi
+
+pushd $git_root
+docker build -t dask-gateway-server-test -f resources/helm/testing/images/dask-gateway-server/Dockerfile .
+popd

--- a/resources/helm/testing/images/dask-gateway-server/Dockerfile
+++ b/resources/helm/testing/images/dask-gateway-server/Dockerfile
@@ -1,0 +1,10 @@
+FROM daskgateway/dask-gateway-server:latest
+
+RUN /opt/conda/bin/conda install -c conda-forge go
+ENV GOOS=linux GOARCH=amd64
+
+# Install dask-gateway-server
+COPY ./dask-gateway-server /source
+USER root
+RUN /usr/bin/env bash -c "cd /source && pip uninstall dask-gateway-server -y && python setup.py build_go install"
+USER dask

--- a/resources/helm/testing/images/dask-gateway/Dockerfile
+++ b/resources/helm/testing/images/dask-gateway/Dockerfile
@@ -1,0 +1,5 @@
+FROM daskgateway/dask-gateway:latest
+
+# Install dask-gateway
+COPY ./dask-gateway /source
+RUN /opt/conda/bin/pip install -U /source

--- a/resources/helm/testing/minikube-config-test-images.yaml
+++ b/resources/helm/testing/minikube-config-test-images.yaml
@@ -1,0 +1,19 @@
+gateway:
+  image:
+    name: dask-gateway-server-test
+    tag: latest
+
+  clusterManager:
+    image:
+      name: dask-gateway-test
+      tag: latest
+
+schedulerProxy:
+  image:
+    name: dask-gateway-server-test
+    tag: latest
+
+webProxy:
+  image:
+    name: dask-gateway-server-test
+    tag: latest


### PR DESCRIPTION
Uses new `*_connect_url` configuration options to better configure
addresses between services. Also adds scripts for starting the chart
on minikube using `dask-gateway` master, which can be useful for
testing.