### PR TITLE
Use chartpress to publish helm chart repo

### DIFF
--- a/resources/helm/chartpress.yaml
+++ b/resources/helm/chartpress.yaml
@@ -1,0 +1,5 @@
+charts:
+  - name: dask-gateway
+    repo:
+      git: dask/dask-gateway-helm-repo
+      published: https://dask.github.io/dask-gateway-helm-repo

--- a/resources/helm/dask-gateway/Chart.yaml
+++ b/resources/helm/dask-gateway/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: dask-gateway
-version: 0.1.0
+version: 0.4.1
 appVersion: 0.4.1
 description: A multi-tenant server for deploying and managing Dask clusters
 home: https://gateway.dask.org/


### PR DESCRIPTION
We don't automate this for now, but the basic setup is complete.