### PR TITLE
Fail on config load error

### DIFF
--- a/dask-gateway-server/dask_gateway_server/app.py
+++ b/dask-gateway-server/dask_gateway_server/app.py
@@ -136,6 +136,9 @@ class DaskGateway(Application):
         "dask_gateway_config.py", help="The config file to load", config=True
     )
 
+    # Fail if the config file errors
+    raise_config_file_errors = True
+
     scheduler_proxy_class = Type(
         "dask_gateway_server.proxy.SchedulerProxy",
         help="The gateway scheduler proxy class to use",


### PR DESCRIPTION
Fail hard if a config file errors. Previously the error would be logged
and then the config file ignored.