### PR TITLE
Template values in client config

### DIFF
--- a/dask-gateway/dask_gateway/auth.py
+++ b/dask-gateway/dask_gateway/auth.py
@@ -6,6 +6,8 @@ from urllib.parse import urlparse
 
 import dask
 
+from .utils import format_template
+
 
 __all__ = ("GatewayAuth", "BasicAuth", "KerberosAuth", "JupyterHubAuth", "get_auth")
 
@@ -48,6 +50,7 @@ def get_auth(auth=None):
         raise TypeError("Unknown auth value %r" % auth)
 
     auth_kwargs = dask.config.get("gateway.auth.kwargs", None) or {}
+    auth_kwargs = {k: format_template(v) for k, v in auth_kwargs.items()}
     out = auth(**auth_kwargs)
 
     if not isinstance(out, GatewayAuth):

--- a/dask-gateway/dask_gateway/client.py
+++ b/dask-gateway/dask_gateway/client.py
@@ -23,6 +23,7 @@ from .cookiejar import CookieJar
 from . import comm
 from .auth import get_auth
 from .options import Options
+from .utils import format_template
 
 del comm
 
@@ -246,7 +247,7 @@ class Gateway(object):
         self, address=None, proxy_address=None, auth=None, asynchronous=False, loop=None
     ):
         if address is None:
-            address = dask.config.get("gateway.address")
+            address = format_template(dask.config.get("gateway.address"))
         if address is None:
             raise ValueError(
                 "No dask-gateway address provided or found in configuration"
@@ -254,7 +255,7 @@ class Gateway(object):
         address = address.rstrip("/")
 
         if proxy_address is None:
-            proxy_address = dask.config.get("gateway.proxy-address")
+            proxy_address = format_template(dask.config.get("gateway.proxy-address"))
         if proxy_address is None:
             raise ValueError(
                 "No dask-gateway proxy address provided or found in configuration"

--- a/dask-gateway/dask_gateway/gateway.yaml
+++ b/dask-gateway/dask_gateway/gateway.yaml
@@ -1,9 +1,13 @@
 gateway:
-  address: null         # The full address to the dask-gateway server
+  address: null         # The full address to the dask-gateway server.
+                        # May also be a template string, which will be formatted
+                        # with any environment variables before usage.
 
   proxy-address: 8786   # The full address or port to the dask-gateway
-                        # scheduler proxy. If a port, the host/ip is taken
-                        # from ``address``.
+                        # scheduler proxy. If a port, the host/ip is taken from
+                        # ``address``. May also be a template string, which
+                        # will be formatted with any environment variables
+                        # before usage.
 
   auth:
     type: basic         # The authentication type to use. Options are basic,
@@ -11,4 +15,6 @@ gateway:
                         # custom class.
 
     kwargs: {}          # Keyword arguments to use when instantiating the
-                        # authentication class above.
+                        # authentication class above. Values may be template
+                        # strings, which will be formatted with any environment
+                        # variables before usage.

--- a/dask-gateway/dask_gateway/utils.py
+++ b/dask-gateway/dask_gateway/utils.py
@@ -1,0 +1,7 @@
+import os
+
+
+def format_template(x):
+    if isinstance(x, str):
+        return x.format(**os.environ)
+    return x


### PR DESCRIPTION
Allows templating of certain config values by environment variables in
the ``dask-gateway`` client config. The following config keys support
this:

- ``gateway.address``
- ``gateway.proxy-address``
- ``gateway.auth.kwargs`` (values only)