### PR TITLE
Add client-side cluster options defaults

### DIFF
--- a/dask-gateway/dask_gateway/client.py
+++ b/dask-gateway/dask_gateway/client.py
@@ -411,25 +411,24 @@ class Gateway(object):
         opts = dask.config.get("gateway.cluster.options")
         return {k: format_template(v) for k, v in opts.items()}
 
-    async def _cluster_options(self, disable_local_defaults=False):
+    async def _cluster_options(self, use_local_defaults=True):
         url = "%s/gateway/api/clusters/options" % self.address
         req = HTTPRequest(url=url, method="GET")
         resp = await self._fetch(req)
         data = json.loads(resp.body)
         options = Options._from_spec(data["cluster_options"])
-        if not disable_local_defaults:
+        if use_local_defaults:
             options.update(self._config_cluster_options())
         return options
 
-    def cluster_options(self, disable_local_defaults=False, **kwargs):
+    def cluster_options(self, use_local_defaults=True, **kwargs):
         """Get the available cluster configuration options.
 
         Parameters
         ----------
-        disable_local_defaults : bool, optional
-            Whether to disable using any default options from the local
-            configuration and get only the server-side defaults instead.
-            Default is False.
+        use_local_defaults : bool, optional
+            Whether to use any default options from the local configuration.
+            Default is True, set to False to use only the server-side defaults.
 
         Returns
         -------
@@ -437,9 +436,7 @@ class Gateway(object):
             A dict of cluster options.
         """
         return self.sync(
-            self._cluster_options,
-            disable_local_defaults=disable_local_defaults,
-            **kwargs,
+            self._cluster_options, use_local_defaults=use_local_defaults, **kwargs
         )
 
     async def _submit(self, cluster_options=None, **kwargs):

--- a/dask-gateway/dask_gateway/client.py
+++ b/dask-gateway/dask_gateway/client.py
@@ -407,22 +407,40 @@ class Gateway(object):
         """
         return self.sync(self._clusters, status=status, **kwargs)
 
-    async def _cluster_options(self):
+    def _config_cluster_options(self):
+        opts = dask.config.get("gateway.cluster.options")
+        return {k: format_template(v) for k, v in opts.items()}
+
+    async def _cluster_options(self, disable_local_defaults=False):
         url = "%s/gateway/api/clusters/options" % self.address
         req = HTTPRequest(url=url, method="GET")
         resp = await self._fetch(req)
         data = json.loads(resp.body)
-        return Options._from_spec(data["cluster_options"])
+        options = Options._from_spec(data["cluster_options"])
+        if not disable_local_defaults:
+            options.update(self._config_cluster_options())
+        return options
 
-    def cluster_options(self, **kwargs):
+    def cluster_options(self, disable_local_defaults=False, **kwargs):
         """Get the available cluster configuration options.
+
+        Parameters
+        ----------
+        disable_local_defaults : bool, optional
+            Whether to disable using any default options from the local
+            configuration and get only the server-side defaults instead.
+            Default is False.
 
         Returns
         -------
         cluster_options : Options
             A dict of cluster options.
         """
-        return self.sync(self._cluster_options, **kwargs)
+        return self.sync(
+            self._cluster_options,
+            disable_local_defaults=disable_local_defaults,
+            **kwargs,
+        )
 
     async def _submit(self, cluster_options=None, **kwargs):
         url = "%s/gateway/api/clusters/" % self.address
@@ -435,7 +453,8 @@ class Gateway(object):
             options = dict(cluster_options)
             options.update(kwargs)
         else:
-            options = kwargs
+            options = self._config_cluster_options()
+            options.update(kwargs)
         req = HTTPRequest(
             url=url,
             method="POST",
@@ -467,7 +486,7 @@ class Gateway(object):
         cluster_name : str
             The cluster name.
         """
-        return self.sync(self._submit, **kwargs)
+        return self.sync(self._submit, cluster_options=cluster_options, **kwargs)
 
     async def _cluster_report(self, cluster_name, wait=False):
         params = "?wait" if wait else ""

--- a/dask-gateway/dask_gateway/gateway.yaml
+++ b/dask-gateway/dask_gateway/gateway.yaml
@@ -5,9 +5,7 @@ gateway:
 
   proxy-address: 8786   # The full address or port to the dask-gateway
                         # scheduler proxy. If a port, the host/ip is taken from
-                        # ``address``. May also be a template string, which
-                        # will be formatted with any environment variables
-                        # before usage.
+                        # ``address``. May also be a template string.
 
   auth:
     type: basic         # The authentication type to use. Options are basic,
@@ -16,5 +14,8 @@ gateway:
 
     kwargs: {}          # Keyword arguments to use when instantiating the
                         # authentication class above. Values may be template
-                        # strings, which will be formatted with any environment
-                        # variables before usage.
+                        # strings.
+
+  cluster:
+    options: {}         # Default options to use when calling ``new_cluster`` or
+                        # ``cluster_options``. Values may be template strings.

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -686,7 +686,7 @@ async def test_cluster_manager_options_client_config(tmpdir, monkeypatch):
                 assert opts.option_one == 2
                 assert opts.option_two == "small"
                 # Without local config, uses server-side defaults
-                opts = await gateway.cluster_options(disable_local_defaults=True)
+                opts = await gateway.cluster_options(use_local_defaults=False)
                 assert opts.option_one == 1
                 assert opts.option_two == "small"
 

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -8,6 +8,7 @@ from cryptography.fernet import Fernet
 from traitlets import Integer, Float
 from traitlets.config import Config
 
+import dask
 from dask_gateway import Gateway, GatewayClusterError, GatewayWarning
 from dask_gateway_server.app import DaskGateway
 from dask_gateway_server.compat import get_running_loop
@@ -657,6 +658,65 @@ async def test_cluster_manager_options(tmpdir):
             with pytest.raises(ValueError) as exc:
                 await gateway.new_cluster(option_two="medium")
             assert "option_two" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_cluster_manager_options_client_config(tmpdir, monkeypatch):
+    monkeypatch.setenv("TEST_OPTION_TWO", "large")
+
+    async with temp_gateway(
+        cluster_manager_class=ClusterOptionsManager,
+        cluster_manager_options=options.Options(
+            options.Integer(
+                "option_one", default=1, min=1, max=4, target="option_one_b"
+            ),
+            options.Select("option_two", options=[("small", 1.5), ("large", 15)]),
+        ),
+        temp_dir=str(tmpdir.join("dask-gateway")),
+    ) as gateway_proc:
+        async with Gateway(
+            address=gateway_proc.public_urls.connect_url,
+            proxy_address=gateway_proc.gateway_urls.connect_url,
+            asynchronous=True,
+        ) as gateway:
+
+            with dask.config.set(gateway__cluster__options={"option_one": 2}):
+                # Local config can override
+                opts = await gateway.cluster_options()
+                assert opts.option_one == 2
+                assert opts.option_two == "small"
+                # Without local config, uses server-side defaults
+                opts = await gateway.cluster_options(disable_local_defaults=True)
+                assert opts.option_one == 1
+                assert opts.option_two == "small"
+
+            with dask.config.set(
+                gateway__cluster__options={"option_two": "{TEST_OPTION_TWO}"}
+            ):
+                # Values can format from environment variables
+                opts = await gateway.cluster_options()
+                assert opts.option_one == 1
+                assert opts.option_two == "large"
+
+            with dask.config.set(
+                gateway__cluster__options={
+                    "option_two": "{TEST_OPTION_TWO}",
+                    "option_one": 3,
+                }
+            ):
+                # Defaults are merged with kwargs to new_cluster
+                cluster = await gateway.new_cluster(option_one=2)
+                cluster_obj = gateway_proc.db.cluster_from_name(cluster.name)
+                assert cluster_obj.options == {"option_one": 2, "option_two": "large"}
+                await cluster.shutdown()
+
+                # If passing `cluster_options`, defaults are assumed already applied
+                opts = await gateway.cluster_options()
+                opts.option_two = "small"
+                cluster = await gateway.new_cluster(opts)
+                cluster_obj = gateway_proc.db.cluster_from_name(cluster.name)
+                assert cluster_obj.options == {"option_one": 3, "option_two": "small"}
+                await cluster.shutdown()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Previously all cluster options (e.g. ``image``, ``worker_cores``,
etc...) had server side defaults only. This was useful for admins to
configure what a default cluster looks like, and in many cases should be
sufficient. In some cases though a default (no kwargs) cluster may rely
on some client-side information. For example, the Pangeo deployment
would like to use the current docker image by default for all workers -
this information is only available on the client side.

This PR adds a ``gateway.cluster.options`` configuration field where
such configurations could be set. The values can be template strings,
formatted with any local environment variables. By default, all calls to
``submit``/``new_cluster`` will use the local default kwargs (with any
explicit kwargs as overrides). Calling ``cluster_options`` will get the
server side defaults, then update them with any local defaults unless
``disable_local_defaults=True`` is specified.

For the pangeo use case, a config file might look like:

```yaml
gateway:
  cluster:
    options:
      image: "JUPYTER_IMAGE_SPEC"
```

Which would then allow:

```python
cluster = gateway.new_cluster()
```

to use the current image without further specification.