### PR TITLE
Use `curl` backend for `httpclient` when available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ dist: xenial
 language: python
 python:
   - "3.6"
+addons:
+  apt:
+    packages:
+      - libgnutls-dev
 
 git:
   depth: false  # Ensure latest tag is pulled

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -16,7 +16,8 @@ pip install \
     ipywidgets \
     notebook \
     black \
-    flake8
+    flake8 \
+    pycurl
 
 pushd dask-gateway
 python setup.py develop

--- a/dask-gateway/dask_gateway/client.py
+++ b/dask-gateway/dask_gateway/client.py
@@ -35,7 +35,7 @@ del comm
 if importlib.util.find_spec("pycurl") is not None:
     _http_client = "tornado.curl_httpclient.CurlAsyncHTTPClient"
 else:
-    _http_client = ""
+    _http_client = "tornado.simple_httpclient.SimpleAsyncHTTPClient"
 
 
 __all__ = ("Gateway", "GatewayCluster", "GatewayClusterError", "GatewayServerError")
@@ -289,11 +289,11 @@ class Gateway(object):
         proxy_address = "gateway://%s" % proxy_netloc
 
         if proxy_config_dict is None:
-            proxy_config_dict = dask.config.get("gateway.proxy_config")
+            proxy_config_dict = dask.config.get("gateway.proxy_config", {})
         if not any(proxy_config_dict.values()):
             AsyncHTTPClient.configure(_http_client, defaults={})
         elif isinstance(proxy_config_dict, dict):
-            if not _http_client:
+            if _http_client == "tornado.simple_httpclient.SimpleAsyncHTTPClient":
                 raise ValueError(
                     "Custom local proxy setup requires `pycurl` but it is not installed"
                 )

--- a/dask-gateway/dask_gateway/client.py
+++ b/dask-gateway/dask_gateway/client.py
@@ -255,9 +255,12 @@ class Gateway(object):
     loop : IOLoop, optional
         The IOLoop instance to use. Defaults to the current loop in
         asynchronous mode, otherwise a background loop is started.
-    proxy_config_defaults : dict, optional
-        Configuration dictionary for the ``CurlAsyncHTTPClient`` to help
-        navigate local proxies. Requires that ``pycurl`` is installed
+    http_client: str, optional
+        Short-name for which http backend to use with Tornado. Either ``curl``
+        or ``simple``. Default is ``curl`` if ``pycurl`` is installed.
+    client_defaults: dict, optional
+        Configuration dictionary to pass to http backend. Needs to be compatible
+        with chosen ``http_client``
     """
 
     def __init__(

--- a/dask-gateway/dask_gateway/gateway.yaml
+++ b/dask-gateway/dask_gateway/gateway.yaml
@@ -21,5 +21,9 @@ gateway:
                         # ``cluster_options``. Values may be template strings.
 
   httpclient:
-    type: null         # The kind of http client to use. One of {"curl", "simple"}. If not provided, curl is used if pycurl is installed, otherwise simple is used.
+    # See link below for available options for selected backend
+    # http://www.tornadoweb.org/en/stable/httpclient.html#http-client-interfaces
+    type: null         # The kind of http client to use. One of
+                       # {"curl", "simple"}. If not provided, curl is used if
+                       # pycurl is installed, otherwise simple is used.
     defaults: null     # A mapping of default parameters to use on every request

--- a/dask-gateway/dask_gateway/gateway.yaml
+++ b/dask-gateway/dask_gateway/gateway.yaml
@@ -19,9 +19,7 @@ gateway:
   cluster:
     options: {}         # Default options to use when calling ``new_cluster`` or
                         # ``cluster_options``. Values may be template strings.
-                        # authentication class above.
 
-  proxy_config:         # Values for a config dictionary for CurlAsyncHTTPClient
-    proxy_host: null    # Local proxy host
-    proxy_port: null    # Local proxy port
-    ca_certs: null      # Custom certificates to use (available from `certifi.where()`)
+  httpclient:
+    type: null         # The kind of http client to use. One of {"curl", "simple"}. If not provided, curl is used if pycurl is installed, otherwise simple is used.
+    defaults: null     # A mapping of default parameters to use on every request

--- a/dask-gateway/dask_gateway/gateway.yaml
+++ b/dask-gateway/dask_gateway/gateway.yaml
@@ -19,3 +19,9 @@ gateway:
   cluster:
     options: {}         # Default options to use when calling ``new_cluster`` or
                         # ``cluster_options``. Values may be template strings.
+                        # authentication class above.
+
+  proxy_config:         # Values for a config dictionary for CurlAsyncHTTPClient
+    proxy_host: null    # Local proxy host
+    proxy_port: null    # Local proxy port
+    ca_certs: null      # Custom certificates to use (available from `certifi.where()`)

--- a/dask-gateway/dask_gateway/utils.py
+++ b/dask-gateway/dask_gateway/utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import importlib
 
 
 def format_template(x):
@@ -14,3 +15,46 @@ async def cancel_task(task):
         await task
     except asyncio.CancelledError:
         pass
+
+
+def _has_pycurl():
+    HAS_PYCURL = False
+    if importlib.util.find_spec("pycurl") is not None:
+        HAS_PYCURL = True
+
+    return HAS_PYCURL
+
+
+def select_tornado_backend(backend=None):
+    """Helper function to handle which tornado backend to use
+
+    Parameters
+    ----------
+    backend : str, optional, one of ``("curl", "simple")``
+        Which backend to use -- ``curl`` backend requires ``pycurl`` to be
+        installed
+
+    Returns
+    -------
+    name of backend to use : str
+    """
+
+    if backend is not None and backend not in ("curl", "simple"):
+        raise ValueError("`backend` should be one of `curl` or `simple`")
+
+    # Configure default AsyncClient backend
+    HTTP_CLIENTS = {
+        "curl": "tornado.curl_httpclient.CurlAsyncHTTPClient",
+        "simple": "tornado.simple_httpclient.SimpleAsyncHTTPClient",
+    }
+
+    HAS_PYCURL = _has_pycurl()
+
+    if backend is None and HAS_PYCURL:
+        return HTTP_CLIENTS["curl"]
+    elif backend is "curl" and not HAS_PYCURL:
+        raise ValueError("`curl` client requires `pycurl` but it is not installed")
+    elif backend is None:
+        return HTTP_CLIENTS["simple"]
+    else:
+        return HTTP_CLIENTS[backend]

--- a/dask-gateway/dask_gateway/utils.py
+++ b/dask-gateway/dask_gateway/utils.py
@@ -1,6 +1,5 @@
 import asyncio
 import os
-import importlib
 
 
 def format_template(x):
@@ -18,11 +17,11 @@ async def cancel_task(task):
 
 
 def _has_pycurl():
-    HAS_PYCURL = False
-    if importlib.util.find_spec("pycurl") is not None:
-        HAS_PYCURL = True
-
-    return HAS_PYCURL
+    try:
+        import pycurl
+        return True
+    except ImportError:
+        return False
 
 
 def select_tornado_backend(backend=None):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -120,7 +120,6 @@ def test_client_init():
             "address": None,
             "proxy-address": 8786,
             "auth": {"type": "basic", "kwargs": {}},
-            "proxy_config": {"proxy_host": None, "proxy_port": None, "ca_certs": None},
         }
     }
 
@@ -164,16 +163,35 @@ def test_local_proxy(monkeypatch):
         }
     }
     with dask.config.set(config):
+        monkeypatch.setattr(client, "_http_client", "tornado.curl_httpclient.CurlAsyncHTTPClient")
         Gateway()
 
     with dask.config.set(config):
-        monkeypatch.setattr(client, "_http_client", "")
+        monkeypatch.setattr(client, "_http_client", "tornado.simple_httpclient.SimpleAsyncHTTPClient")
         with pytest.raises(ValueError):
             Gateway()
 
     with pytest.raises(ValueError):
         Gateway(proxy_config_dict="HI")
 
+    config = {
+        "gateway": {
+            "address": "http://127.0.0.1:8888",
+            "proxy-address": 8786,
+            "auth": {"type": "basic", "kwargs": {}},
+        }
+    }
+
+    with dask.config.set(config):
+        monkeypatch.setattr(client, "_http_client", "tornado.curl_httpclient.CurlAsyncHTTPClient")
+        Gateway()
+
+    with dask.config.set(config):
+        monkeypatch.setattr(client, "_http_client", "tornado.simple_httpclient.SimpleAsyncHTTPClient")
+        Gateway()
+
+    with pytest.raises(ValueError):
+        Gateway(proxy_config_dict="HI")
 
 class SlowHandler(web.RequestHandler):
     async def get(self):

--- a/tests/test_client_utils.py
+++ b/tests/test_client_utils.py
@@ -1,0 +1,34 @@
+import pytest
+
+from dask_gateway import utils
+
+HTTP_CLIENTS = {
+    "curl": "tornado.curl_httpclient.CurlAsyncHTTPClient",
+    "simple": "tornado.simple_httpclient.SimpleAsyncHTTPClient",
+}
+
+
+def test_tornado_backend_selector(monkeypatch):
+    pytest.importorskip("pycurl")
+
+    with pytest.raises(ValueError):
+        utils.select_tornado_backend("junk")
+
+    monkeypatch.setattr(utils, "_has_pycurl", lambda: False)
+    with pytest.raises(ValueError):
+        utils.select_tornado_backend(backend="curl")
+
+    monkeypatch.setattr(utils, "_has_pycurl", lambda: True)
+    backend = utils.select_tornado_backend()
+    assert backend == HTTP_CLIENTS["curl"]
+    backend = utils.select_tornado_backend(backend="curl")
+    assert backend == HTTP_CLIENTS["curl"]
+
+    backend = utils.select_tornado_backend(backend="simple")
+    assert backend == HTTP_CLIENTS["simple"]
+
+    monkeypatch.setattr(utils, "_has_pycurl", lambda: False)
+    backend = utils.select_tornado_backend()
+    assert backend == HTTP_CLIENTS["simple"]
+    backend = utils.select_tornado_backend(backend="simple")
+    assert backend == HTTP_CLIENTS["simple"]


### PR DESCRIPTION
Users with local enterprise proxies often need to include additional
configuration items when passing requests. The `CurlAsyncHTTPClient`
allows for specifying a local proxy and port to tunnel requests through,
but also requires that `pycurl` is installed.

This adds a configuration section to `gateway.yaml` with some commonly
specified options and sets `CurlAsyncHTTPClient` as the default backend
if `pycurl` is available.

If someone specifies proxy configuration but `pycurl` isn't present, it
will raise an error to complain about the missing dependency, otherwise
it just uses the default tornado backend.

Suggest that with this change that `pycurl` is added to the
`dask-gateway` feedstock runtime requirements

Fixes #103 