### PR TITLE
Improve compatibility with standard dask cluster interface

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       language_version: python3.7
 
 - repo: https://gitlab.com/pycqa/flake8
-  rev: 3.7.7
+  rev: 3.7.8
   hooks:
     - id: flake8
       exclude: >

--- a/dask-gateway-server/dask_gateway_server/app.py
+++ b/dask-gateway-server/dask_gateway_server/app.py
@@ -318,6 +318,7 @@ class DaskGateway(Application):
         checking a cluster's status before deciding that the cluster is no
         longer active.
         """,
+        config=True,
     )
 
     db_url = Unicode(

--- a/dask-gateway/dask_gateway/utils.py
+++ b/dask-gateway/dask_gateway/utils.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 
 
@@ -5,3 +6,11 @@ def format_template(x):
     if isinstance(x, str):
         return x.format(**os.environ)
     return x
+
+
+async def cancel_task(task):
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,7 +3,7 @@ import asyncio
 import pytest
 import dask
 from dask_gateway.auth import get_auth, BasicAuth, KerberosAuth, JupyterHubAuth
-from dask_gateway.client import Gateway
+from dask_gateway.client import Gateway, GatewayCluster, cleanup_lingering_clusters
 from dask_gateway_server.managers.inprocess import InProcessClusterManager
 from dask_gateway_server.utils import random_port
 from tornado import web
@@ -216,3 +216,114 @@ async def test_client_reprs(tmpdir):
             # HTML repr with no dashboard
             cluster.dashboard_link = None
             assert "Not Available" in cluster._repr_html_()
+
+
+@pytest.mark.asyncio
+async def test_create_cluster_with_GatewayCluster_constructor(tmpdir):
+    async with temp_gateway(
+        cluster_manager_class=InProcessClusterManager,
+        temp_dir=str(tmpdir.join("dask-gateway")),
+    ) as gateway_proc:
+        async with GatewayCluster(
+            address=gateway_proc.public_urls.connect_url,
+            proxy_address=gateway_proc.gateway_urls.connect_url,
+            asynchronous=True,
+        ) as cluster:
+
+            # Cluster is now present in list
+            clusters = await cluster.gateway.list_clusters()
+            assert len(clusters)
+            assert clusters[0].name == cluster.name
+
+            await cluster.scale(1)
+
+            with cluster.get_client(set_as_default=False) as client:
+                res = await client.submit(lambda x: x + 1, 1)
+                assert res == 2
+
+        assert cluster.status == "closed"
+
+        async with Gateway(
+            address=gateway_proc.public_urls.connect_url,
+            proxy_address=gateway_proc.gateway_urls.connect_url,
+            asynchronous=True,
+        ) as gateway:
+            # No cluster running
+            clusters = await gateway.list_clusters()
+            assert not clusters
+
+
+@pytest.mark.asyncio
+async def test_GatewayCluster_shutdown_on_close(tmpdir):
+    async with temp_gateway(
+        cluster_manager_class=InProcessClusterManager,
+        temp_dir=str(tmpdir.join("dask-gateway")),
+    ) as gateway_proc:
+
+        def test():
+            cluster = GatewayCluster(
+                address=gateway_proc.public_urls.connect_url,
+                proxy_address=gateway_proc.gateway_urls.connect_url,
+            )
+            assert cluster.shutdown_on_close
+            assert cluster in GatewayCluster._instances
+
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, test)
+
+        assert len(GatewayCluster._instances) == 0
+
+        async with Gateway(
+            address=gateway_proc.public_urls.connect_url,
+            proxy_address=gateway_proc.gateway_urls.connect_url,
+            asynchronous=True,
+        ) as gateway:
+            # No cluster running
+            clusters = await gateway.list_clusters()
+            assert not clusters
+
+
+@pytest.mark.asyncio
+async def test_GatewayCluster_cleanup_atexit(tmpdir):
+    async with temp_gateway(
+        cluster_manager_class=InProcessClusterManager,
+        temp_dir=str(tmpdir.join("dask-gateway")),
+    ) as gateway_proc:
+
+        def test():
+            return GatewayCluster(
+                address=gateway_proc.public_urls.connect_url,
+                proxy_address=gateway_proc.gateway_urls.connect_url,
+            )
+
+        loop = asyncio.get_running_loop()
+        cluster = await loop.run_in_executor(None, test)
+
+        assert len(GatewayCluster._instances) == 1
+
+        def test_cleanup():
+            # No warnings raised by cleanup function
+            with pytest.warns(None) as rec:
+                cleanup_lingering_clusters()
+            for r in rec:
+                assert not issubclass(r.category, UserWarning)
+
+            # Cluster is now closed
+            assert cluster.status == "closed"
+
+            # No harm in double running
+            with pytest.warns(None) as rec:
+                cleanup_lingering_clusters()
+            for r in rec:
+                assert not issubclass(r.category, UserWarning)
+
+        await loop.run_in_executor(None, test_cleanup)
+
+        async with Gateway(
+            address=gateway_proc.public_urls.connect_url,
+            proxy_address=gateway_proc.gateway_urls.connect_url,
+            asynchronous=True,
+        ) as gateway:
+            # No cluster running
+            clusters = await gateway.list_clusters()
+            assert not clusters

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,6 +4,7 @@ import pytest
 import dask
 from dask_gateway.auth import get_auth, BasicAuth, KerberosAuth, JupyterHubAuth
 from dask_gateway.client import Gateway, GatewayCluster, cleanup_lingering_clusters
+from dask_gateway_server.compat import get_running_loop
 from dask_gateway_server.managers.inprocess import InProcessClusterManager
 from dask_gateway_server.utils import random_port
 from tornado import web
@@ -268,7 +269,7 @@ async def test_GatewayCluster_shutdown_on_close(tmpdir):
             assert cluster.shutdown_on_close
             assert cluster in GatewayCluster._instances
 
-        loop = asyncio.get_running_loop()
+        loop = get_running_loop()
         await loop.run_in_executor(None, test)
 
         assert len(GatewayCluster._instances) == 0
@@ -296,7 +297,7 @@ async def test_GatewayCluster_cleanup_atexit(tmpdir):
                 proxy_address=gateway_proc.gateway_urls.connect_url,
             )
 
-        loop = asyncio.get_running_loop()
+        loop = get_running_loop()
         cluster = await loop.run_in_executor(None, test)
 
         assert len(GatewayCluster._instances) == 1

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -97,7 +97,7 @@ def test_client_init():
         gateway = Gateway()
         assert gateway.address == "http://127.0.0.1:8888"
         assert gateway.proxy_address == "gateway://127.0.0.1:8786"
-        assert gateway._auth.username == "bruce"
+        assert gateway.auth.username == "bruce"
 
         # Address override
         gateway = Gateway(address="http://127.0.0.1:9999")
@@ -109,7 +109,7 @@ def test_client_init():
 
         # Auth override
         gateway = Gateway(auth="kerberos")
-        assert isinstance(gateway._auth, KerberosAuth)
+        assert isinstance(gateway.auth, KerberosAuth)
 
     config = {
         "gateway": {

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,6 +4,7 @@ import pytest
 import dask
 from dask_gateway.auth import get_auth, BasicAuth, KerberosAuth, JupyterHubAuth
 from dask_gateway.client import Gateway
+from dask_gateway_server.managers.inprocess import InProcessClusterManager
 from dask_gateway_server.utils import random_port
 from tornado import web
 from tornado.httpclient import HTTPRequest
@@ -190,9 +191,14 @@ async def test_client_fetch_timeout():
 
 @pytest.mark.asyncio
 async def test_client_reprs(tmpdir):
-    async with temp_gateway(temp_dir=str(tmpdir.join("dask-gateway"))) as gateway_proc:
+    async with temp_gateway(
+        cluster_manager_class=InProcessClusterManager,
+        temp_dir=str(tmpdir.join("dask-gateway")),
+    ) as gateway_proc:
         async with Gateway(
-            address=gateway_proc.public_url, asynchronous=True
+            address=gateway_proc.public_urls.connect_url,
+            proxy_address=gateway_proc.gateway_urls.connect_url,
+            asynchronous=True,
         ) as gateway:
             cluster = await gateway.new_cluster()
 


### PR DESCRIPTION
Previously we were *mostly* compatible with other dask cluster managers, but not 100% compatible. This PR changes this by adding the following:

- By default, in synchronous mode any cluster created will be automatically shutdown on garbage collection/client process shutdown. This can be disabled by setting `shutdown_on_close=False` in any of the `GatewayCluster` construction methods. By default this parameter is `True` in `Gateway.new_cluster`/`GatewayCluster`, and False in `Gateway.connect` (since you're connecting to an already running cluster, you probably don't want to automatically shut it down).
- `GatewayCluster` is now an awaitable, and all methods that return one (`new_cluster`/`connect`) now return a `GatewayCluster` directly instead of a future that resolves to one. This makes it easier to use these methods as async context managers without adding an extra step.
- `GatewayCluster` can now be used directly as a constructor, instead of requiring `Gateway.new_cluster` by used. This makes it easier to drop in to existing workloads, and makes it compatible with things like `dask-labextension` (note that until https://github.com/dask/distributed/issues/3107 is resolved, this won't be fully compatible).