### PR TITLE
Helm upgrade restarts pods as needed

### DIFF
--- a/docs/source/install-kube.rst
+++ b/docs/source/install-kube.rst
@@ -79,17 +79,15 @@ To install the Dask-Gateway Helm chart, run the following command:
     NAMESPACE=dask-gateway
     VERSION=0.4.1
 
-    helm install \
-        --name $RELEASE \
+    helm upgrade --install \
         --namespace $NAMESPACE \
         --version $VERSION \
         --values path/to/your/config.yaml \
+        $RELEASE \
         dask-gateway/dask-gateway
 
 where:
 
-- ``path/to/your/config.yaml`` is the path to your ``config.yaml`` file created
-  above.
 - ``RELEASE`` is the `Helm release name`_ to use (we suggest ``dask-gateway``,
   but any release name is fine).
 - ``NAMESPACE`` is the `Kubernetes namespace`_ to install the gateway into (we
@@ -97,6 +95,8 @@ where:
 - ``VERSION`` is the Helm chart version to use. To use the latest published
   version you can omit the ``--version`` flag entirely. See the `Helm chart
   repository`_ for an index of all available versions.
+- ``path/to/your/config.yaml`` is the path to your ``config.yaml`` file created
+  above.
 
 Running this command may take some time, as resources are created and images
 are downloaded. When everything's ready, running the following command will

--- a/resources/helm/dask-gateway/templates/gateway-deployment.yaml
+++ b/resources/helm/dask-gateway/templates/gateway-deployment.yaml
@@ -19,6 +19,9 @@ spec:
       labels:
         {{- include "dask-gateway.labels" . | nindent 8 }}
         app.kubernetes.io/component: gateway
+      annotations:
+        checksum/configmap: {{ include (print .Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum }}
     spec:
       {{- if .Values.rbac.enabled }}
       serviceAccountName: {{ include "dask-gateway.fullname" . }}

--- a/resources/helm/dask-gateway/templates/scheduler-proxy-deployment.yaml
+++ b/resources/helm/dask-gateway/templates/scheduler-proxy-deployment.yaml
@@ -19,6 +19,8 @@ spec:
       labels:
         {{- include "dask-gateway.labels" . | nindent 8 }}
         app.kubernetes.io/component: scheduler-proxy
+      annotations:
+        checksum/secret: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum }}
     spec:
       volumes:
         - name: configmap

--- a/resources/helm/dask-gateway/templates/web-proxy-deployment.yaml
+++ b/resources/helm/dask-gateway/templates/web-proxy-deployment.yaml
@@ -19,6 +19,8 @@ spec:
       labels:
         {{- include "dask-gateway.labels" . | nindent 8 }}
         app.kubernetes.io/component: web-proxy
+      annotations:
+        checksum/secret: {{ include (print .Template.BasePath "/secret.yaml") . | sha256sum }}
     spec:
       volumes:
         - name: configmap


### PR DESCRIPTION
Previously if a configmap or secret changed, the pods depending on that
configmap/secret wouldn't restart, and the changes wouldn't be picked
up. We now include relevant checksum annotations in the deployments to
force restarts as needed.

Fixes #123.