### PR TITLE
Remove versions from matchLabels in helm chart

### DIFF
--- a/resources/helm/dask-gateway/templates/_helpers.tpl
+++ b/resources/helm/dask-gateway/templates/_helpers.tpl
@@ -43,3 +43,12 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
+
+{{/*
+Match labels
+*/}}
+{{- define "dask-gateway.matchLabels" -}}
+app.kubernetes.io/name: {{ include "dask-gateway.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/resources/helm/dask-gateway/templates/gateway-deployment.yaml
+++ b/resources/helm/dask-gateway/templates/gateway-deployment.yaml
@@ -12,7 +12,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "dask-gateway.labels" . | nindent 6 }}
+      {{- include "dask-gateway.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: gateway
   template:
     metadata:

--- a/resources/helm/dask-gateway/templates/scheduler-proxy-deployment.yaml
+++ b/resources/helm/dask-gateway/templates/scheduler-proxy-deployment.yaml
@@ -12,7 +12,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "dask-gateway.labels" . | nindent 6 }}
+      {{- include "dask-gateway.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: scheduler-proxy
   template:
     metadata:

--- a/resources/helm/dask-gateway/templates/web-proxy-deployment.yaml
+++ b/resources/helm/dask-gateway/templates/web-proxy-deployment.yaml
@@ -12,7 +12,7 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "dask-gateway.labels" . | nindent 6 }}
+      {{- include "dask-gateway.matchLabels" . | nindent 6 }}
       app.kubernetes.io/component: web-proxy
   template:
     metadata:


### PR DESCRIPTION
Despite helm's recommendations, versions should *not* be included in
`matchLabels` in deployments, as they're immutable once created.
Including versions or other frequently changing things in `matchLabels`
means that `helm upgrade` will fail if the chart/app version increments,
as the `matchLabels` cannot be updated.

Fixes #147.