### PR TITLE
Error nicely if JupyterHub API url isn't found

### DIFF
--- a/docs/source/install-kube.rst
+++ b/docs/source/install-kube.rst
@@ -237,6 +237,21 @@ Then add the following lines to your ``config.yaml`` file:
 
 replacing ``<API TOKEN>`` with the output from above.
 
+If you're not deploying Dask-Gateway in the same cluster and namespace as
+JupyterHub, you'll also need to specify JupyterHub's API url. This is usually
+of the form ``https://<JUPYTERHUB-HOST>:<JUPYTERHUB-PORT>/hub/api``. If
+JupyterHub and Dask-Gateway are on the same cluster and namespace you can omit
+this configuration key, the address will be inferred automatically.
+
+.. code-block:: yaml
+
+    gateway:
+      auth:
+        type: jupyterhub
+        jupyterhub:
+          apiToken: "<API TOKEN>"
+          apiUrl: "<API URL>"
+
 You'll also need to add the following to the ``config.yaml`` file for your
 JupyterHub Helm Chart.
 

--- a/resources/helm/dask-gateway/templates/configmap.yaml
+++ b/resources/helm/dask-gateway/templates/configmap.yaml
@@ -119,7 +119,14 @@ data:
         c.DaskGateway.authenticator_class = "dask_gateway_server.auth.JupyterHubAuthenticator"
         api_url = get_property("gateway.auth.jupyterhub.apiUrl")
         if api_url is None:
-            api_url = "http://{HUB_SERVICE_HOST}:{HUB_SERVICE_PORT}/hub/api".format(**os.environ)
+            try:
+                api_url = "http://{HUB_SERVICE_HOST}:{HUB_SERVICE_PORT}/hub/api".format(**os.environ)
+            except Exception:
+                raise ValueError(
+                    "Failed to infer JupyterHub API url from environment, "
+                    "please specify `gateway.auth.jupyterhub.apiUrl` in "
+                    "your config file"
+                )
         c.DaskGateway.JupyterHubAuthenticator.jupyterhub_api_url = api_url
     elif auth_type == "custom":
         auth_cls = get_property("gateway.auth.custom.class")


### PR DESCRIPTION
When configuring dask-gateway to use JupyterHub for authentication in
kubernetes, JupyterHub's API url is inferred from the environment if:

- JupyterHub was started using the zero-to-jupyterhub chart
- Dask-Gateway and JupyterHub are running in the same cluster
- Dask-Gateway and JupyterHub are running in the same namespace

If this isn't true, the user needs to manually configure the api url in
the helm values. We update the documentation to reflect this, and
improve the error message raised in this case.

Fixes #131.