### PR TITLE
Adaptive scaling

### DIFF
--- a/dask-gateway-server/dask_gateway_server/managers/base.py
+++ b/dask-gateway-server/dask_gateway_server/managers/base.py
@@ -176,12 +176,12 @@ class ClusterManager(LoggingConfigurable):
     @property
     def worker_command(self):
         """The full command (as a string) to launch a dask worker"""
-        return " ".join(self.worker_commmand_list)
+        return " ".join(self.worker_command_list)
 
     @property
     def scheduler_command(self):
         """The full command (as a string) to launch a dask scheduler"""
-        return " ".join(self.scheduler_commmand_list)
+        return " ".join(self.scheduler_command_list)
 
     supports_bulk_shutdown = Bool(
         False,

--- a/dask-gateway-server/dask_gateway_server/managers/base.py
+++ b/dask-gateway-server/dask_gateway_server/managers/base.py
@@ -112,6 +112,19 @@ class ClusterManager(LoggingConfigurable):
         config=True,
     )
 
+    adaptive_period = Float(
+        3,
+        min=0,
+        help="""
+        Time (in seconds) between adaptive scaling checks.
+
+        A smaller period will decrease scale up/down latency when responding to
+        cluster load changes, but may also result in higher load on the gateway
+        server.
+        """,
+        config=True,
+    )
+
     # Cluster-specific parameters forwarded by gateway application
     username = Unicode()
     cluster_name = Unicode()
@@ -143,6 +156,32 @@ class ClusterManager(LoggingConfigurable):
             }
         )
         return out
+
+    @property
+    def worker_command_list(self):
+        """The full command (as an arg list) to launch a dask worker"""
+        return [
+            self.worker_cmd,
+            "--nthreads",
+            str(self.worker_cores),
+            "--memory-limit",
+            str(self.worker_memory),
+        ]
+
+    @property
+    def scheduler_command_list(self):
+        """The full command (as an arg list) to launch a dask scheduler"""
+        return [self.scheduler_cmd, "--adaptive-period", str(self.adaptive_period)]
+
+    @property
+    def worker_command(self):
+        """The full command (as a string) to launch a dask worker"""
+        return " ".join(self.worker_commmand_list)
+
+    @property
+    def scheduler_command(self):
+        """The full command (as a string) to launch a dask scheduler"""
+        return " ".join(self.scheduler_commmand_list)
 
     supports_bulk_shutdown = Bool(
         False,

--- a/dask-gateway-server/dask_gateway_server/managers/inprocess.py
+++ b/dask-gateway-server/dask_gateway_server/managers/inprocess.py
@@ -32,7 +32,10 @@ class InProcessClusterManager(UnsafeLocalClusterManager):
         security = self.get_security()
         gateway_client = self.get_gateway_client()
         self.scheduler = await start_scheduler(
-            gateway_client, security, exit_on_failure=False
+            gateway_client,
+            security,
+            exit_on_failure=False,
+            adaptive_period=self.adaptive_period,
         )
         yield {}
 

--- a/dask-gateway-server/dask_gateway_server/managers/jobqueue/base.py
+++ b/dask-gateway-server/dask_gateway_server/managers/jobqueue/base.py
@@ -144,24 +144,6 @@ class JobQueueClusterManager(ClusterManager):
 
     cancel_command = Unicode(help="The path to the job cancel command", config=True)
 
-    def get_worker_args(self):
-        return [
-            "--nthreads",
-            str(self.worker_cores),
-            "--memory-limit",
-            str(self.worker_memory),
-        ]
-
-    @property
-    def worker_command(self):
-        """The full command (with args) to launch a dask worker"""
-        return " ".join([self.worker_cmd] + self.get_worker_args())
-
-    @property
-    def scheduler_command(self):
-        """The full command (with args) to launch a dask scheduler"""
-        return self.scheduler_cmd
-
     def get_submit_cmd_env_stdin(self, worker_name=None):
         raise NotImplementedError
 

--- a/dask-gateway-server/dask_gateway_server/managers/kubernetes.py
+++ b/dask-gateway-server/dask_gateway_server/managers/kubernetes.py
@@ -504,8 +504,7 @@ class KubeClusterManager(ClusterManager):
         return "/etc/dask-credentials/dask.crt", "/etc/dask-credentials/dask.pem"
 
     @property
-    def worker_command(self):
-        """The full command (with args) to launch a dask worker"""
+    def worker_command_list(self):
         return [
             self.worker_cmd,
             "--nthreads",
@@ -513,11 +512,6 @@ class KubeClusterManager(ClusterManager):
             "--memory-limit",
             str(self.worker_memory_limit),
         ]
-
-    @property
-    def scheduler_command(self):
-        """The full command (with args) to launch a dask scheduler"""
-        return [self.scheduler_cmd]
 
     @property
     def pod_label_selector(self):
@@ -566,7 +560,7 @@ class KubeClusterManager(ClusterManager):
             cpu_req = self.worker_cores
             cpu_lim = self.worker_cores_limit
             env["DASK_GATEWAY_WORKER_NAME"] = worker_name
-            cmd = self.worker_command
+            cmd = self.worker_command_list
             extra_pod_config = self.worker_extra_pod_config
             extra_container_config = self.worker_extra_container_config
         else:
@@ -578,7 +572,7 @@ class KubeClusterManager(ClusterManager):
             mem_lim = self.scheduler_memory_limit
             cpu_req = self.scheduler_cores
             cpu_lim = self.scheduler_cores_limit
-            cmd = self.scheduler_command
+            cmd = self.scheduler_command_list
             extra_pod_config = self.scheduler_extra_pod_config
             extra_container_config = self.scheduler_extra_container_config
 

--- a/dask-gateway-server/dask_gateway_server/managers/local.py
+++ b/dask-gateway-server/dask_gateway_server/managers/local.py
@@ -191,24 +191,6 @@ class LocalClusterManager(ClusterManager):
 
         return preexec
 
-    def get_worker_args(self):
-        return [
-            "--nthreads",
-            str(self.worker_cores),
-            "--memory-limit",
-            str(self.worker_memory),
-        ]
-
-    @property
-    def worker_command(self):
-        """The full command (with args) to launch a dask worker"""
-        return " ".join([self.worker_cmd] + self.get_worker_args())
-
-    @property
-    def scheduler_command(self):
-        """The full command (with args) to launch a dask scheduler"""
-        return self.scheduler_cmd
-
     async def start_process(self, cmd, env, name):
         workdir = self.get_working_directory()
         logsdir = self.get_logs_directory(workdir)
@@ -250,7 +232,7 @@ class LocalClusterManager(ClusterManager):
     async def start_cluster(self):
         self.create_working_directory()
         pid = await self.start_process(
-            self.scheduler_command.split(), self.get_env(), "scheduler"
+            self.scheduler_command_list, self.get_env(), "scheduler"
         )
         yield {"pid": pid}
 
@@ -267,7 +249,7 @@ class LocalClusterManager(ClusterManager):
         self.remove_working_directory()
 
     async def start_worker(self, worker_name, cluster_state):
-        cmd = self.worker_command.split()
+        cmd = self.worker_command_list
         env = self.get_env()
         env["DASK_GATEWAY_WORKER_NAME"] = worker_name
         pid = await self.start_process(cmd, env, "worker-%s" % worker_name)

--- a/dask-gateway-server/dask_gateway_server/managers/yarn.py
+++ b/dask-gateway-server/dask_gateway_server/managers/yarn.py
@@ -220,23 +220,15 @@ class YarnClusterManager(ClusterManager):
                 if os.path.exists(path):
                     os.unlink(path)
 
-    def get_worker_args(self):
+    @property
+    def worker_command_list(self):
         return [
+            self.worker_cmd,
             "--nthreads",
             "$SKEIN_RESOURCE_VCORES",
             "--memory-limit",
             "${SKEIN_RESOURCE_MEMORY}MiB",
         ]
-
-    @property
-    def worker_command(self):
-        """The full command (with args) to launch a dask worker"""
-        return " ".join([self.worker_cmd] + self.get_worker_args())
-
-    @property
-    def scheduler_command(self):
-        """The full command (with args) to launch a dask scheduler"""
-        return self.scheduler_cmd
 
     def _build_specification(self, cert_path, key_path):
         files = {

--- a/dask-gateway-server/dask_gateway_server/objects.py
+++ b/dask-gateway-server/dask_gateway_server/objects.py
@@ -12,6 +12,7 @@ from sqlalchemy import (
     Column,
     Integer,
     Float,
+    Boolean,
     Unicode,
     BINARY,
     ForeignKey,
@@ -137,6 +138,7 @@ clusters = Table(
     Column("dashboard_address", Unicode(255), nullable=False),
     Column("api_address", Unicode(255), nullable=False),
     Column("tls_credentials", LargeBinary, nullable=False),
+    Column("adaptive", Boolean, nullable=False),
     Column("memory", Integer, nullable=False),
     Column("cores", Float, nullable=False),
     Column("start_time", Integer, nullable=False),
@@ -229,6 +231,7 @@ class DataManager(object):
                 api_address=c.api_address,
                 tls_cert=tls_cert,
                 tls_key=tls_key,
+                adaptive=c.adaptive,
                 memory=c.memory,
                 cores=c.cores,
                 start_time=c.start_time,
@@ -348,6 +351,7 @@ class DataManager(object):
             "api_address": "",
             "memory": memory,
             "cores": cores,
+            "adaptive": False,
             "start_time": timestamp(),
         }
 
@@ -443,6 +447,7 @@ class Cluster(object):
         api_address="",
         tls_cert=b"",
         tls_key=b"",
+        adaptive=False,
         memory=None,
         cores=None,
         start_time=None,
@@ -460,6 +465,7 @@ class Cluster(object):
         self.api_address = api_address
         self.tls_cert = tls_cert
         self.tls_key = tls_key
+        self.adaptive = adaptive
         self.memory = memory
         self.cores = cores
         self.start_time = start_time

--- a/dask-gateway-server/dask_gateway_server/utils.py
+++ b/dask-gateway-server/dask_gateway_server/utils.py
@@ -282,3 +282,22 @@ def classname(cls):
     """Return the full qualified name of a class"""
     mod = cls.__module__
     return cls.__name__ if mod is None else f"{mod}.{cls.__name__}"
+
+
+class nullcontext(object):
+    """A no-op context manager"""
+
+    def __init__(self, enter_result=None):
+        self.enter_result = enter_result
+
+    def __enter__(self):
+        return self.enter_result
+
+    def __exit__(self, *args):
+        pass
+
+    async def __aenter__(self):
+        return self.enter_result
+
+    async def __aexit__(self, *args):
+        pass

--- a/dask-gateway/dask_gateway/client.py
+++ b/dask-gateway/dask_gateway/client.py
@@ -1076,7 +1076,7 @@ class GatewayCluster(object):
             return None
 
         try:
-            from ipywidgets import Layout, VBox, HBox, IntText, Button, HTML
+            from ipywidgets import Layout, VBox, HBox, IntText, Button, HTML, Accordion
         except ImportError:
             self._cached_widget = None
             return None
@@ -1090,12 +1090,30 @@ class GatewayCluster(object):
         request = IntText(0, description="Workers", layout=layout)
         scale = Button(description="Scale", layout=layout)
 
+        minimum = IntText(0, description="Minimum", layout=layout)
+        maximum = IntText(0, description="Maximum", layout=layout)
+        adapt = Button(description="Adapt", layout=layout)
+
+        accordion = Accordion(
+            [HBox([request, scale]), HBox([minimum, maximum, adapt])],
+            layout=Layout(min_width="500px"),
+        )
+        accordion.selected_index = None
+        accordion.set_title(0, "Manual Scaling")
+        accordion.set_title(1, "Adaptive Scaling")
+
         @scale.on_click
         def scale_cb(b):
             with log_errors():
                 self.scale(request.value)
 
-        elements = [title, HBox([status, request, scale])]
+        @adapt.on_click
+        def adapt_cb(b):
+            self.adapt(minimum=minimum.value, maximum=maximum.value)
+
+        name = HTML("<p><b>Name: </b>{0}</p>".format(self.name))
+
+        elements = [title, HBox([status, accordion]), name]
 
         if self.dashboard_link is not None:
             link = HTML(

--- a/dask-gateway/dask_gateway/client.py
+++ b/dask-gateway/dask_gateway/client.py
@@ -137,6 +137,8 @@ class ClusterReport(object):
         The address of the scheduler, or None if not currently running.
     dashboard_link : str or None
         A link to the dashboard, or None if not currently running.
+    adaptive : bool
+        Whether the cluster is in adaptive mode.
     start_time : datetime.datetime
         The time the cluster was started.
     stop_time : datetime.datetime or None
@@ -155,6 +157,7 @@ class ClusterReport(object):
         "status",
         "scheduler_address",
         "dashboard_link",
+        "adaptive",
         "start_time",
         "stop_time",
         "tls_cert",
@@ -168,6 +171,7 @@ class ClusterReport(object):
         status,
         scheduler_address,
         dashboard_link,
+        adaptive,
         start_time,
         stop_time,
         tls_cert=None,
@@ -178,6 +182,7 @@ class ClusterReport(object):
         self.status = status
         self.scheduler_address = scheduler_address
         self.dashboard_link = dashboard_link
+        self.adaptive = adaptive
         self.start_time = start_time
         self.stop_time = stop_time
         self.tls_cert = tls_cert
@@ -396,6 +401,20 @@ class Gateway(object):
         """
         return self.sync(self._clusters, status=status, **kwargs)
 
+    def get_cluster(self, cluster_name, **kwargs):
+        """Get information about a specific cluster.
+
+        Parameters
+        ----------
+        cluster_name : str
+            The cluster name.
+
+        Returns
+        -------
+        report : ClusterReport
+        """
+        return self.sync(self._cluster_report, cluster_name, **kwargs)
+
     def _config_cluster_options(self):
         opts = dask.config.get("gateway.cluster.options")
         return {k: format_template(v) for k, v in opts.items()}
@@ -580,10 +599,10 @@ class Gateway(object):
         return self.sync(self._stop_cluster, cluster_name, **kwargs)
 
     async def _scale_cluster(self, cluster_name, n):
-        url = "%s/gateway/api/clusters/%s/workers" % (self.address, cluster_name)
+        url = "%s/gateway/api/clusters/%s/scale" % (self.address, cluster_name)
         req = HTTPRequest(
             url=url,
-            method="PUT",
+            method="POST",
             body=json.dumps({"worker_count": n}),
             headers=HTTPHeaders({"Content-type": "application/json"}),
         )
@@ -603,6 +622,44 @@ class Gateway(object):
             The number of workers to scale to.
         """
         return self.sync(self._scale_cluster, cluster_name, n, **kwargs)
+
+    async def _adapt_cluster(
+        self, cluster_name, minimum=None, maximum=None, active=True
+    ):
+        url = "%s/gateway/api/clusters/%s/adapt" % (self.address, cluster_name)
+        req = HTTPRequest(
+            url=url,
+            method="POST",
+            body=json.dumps({"minimum": minimum, "maximum": maximum, "active": active}),
+            headers=HTTPHeaders({"Content-type": "application/json"}),
+        )
+        await self._fetch(req)
+
+    def adapt_cluster(
+        self, cluster_name, minimum=None, maximum=None, active=True, **kwargs
+    ):
+        """Configure adaptive scaling for a cluster.
+
+        Parameters
+        ----------
+        cluster_name : str
+            The cluster name.
+        minimum : int, optional
+            The minimum number of workers to scale to. Defaults to 0.
+        maximum : int, optional
+            The maximum number of workers to scale to. Defaults to infinity.
+        active : bool, optional
+            If ``True`` (default), adaptive scaling is activated. Set to
+            ``False`` to deactivate adaptive scaling.
+        """
+        return self.sync(
+            self._adapt_cluster,
+            cluster_name,
+            minimum=minimum,
+            maximum=maximum,
+            active=active,
+            **kwargs,
+        )
 
 
 _widget_status_template = """
@@ -949,6 +1006,23 @@ class GatewayCluster(object):
             The number of workers to scale to.
         """
         return self.gateway.scale_cluster(self.name, n, **kwargs)
+
+    def adapt(self, minimum=None, maximum=None, active=True, **kwargs):
+        """Configure adaptive scaling for the cluster.
+
+        Parameters
+        ----------
+        minimum : int, optional
+            The minimum number of workers to scale to. Defaults to 0.
+        maximum : int, optional
+            The maximum number of workers to scale to. Defaults to infinity.
+        active : bool, optional
+            If ``True`` (default), adaptive scaling is activated. Set to
+            ``False`` to deactivate adaptive scaling.
+        """
+        return self.gateway.adapt_cluster(
+            self.name, minimum=minimum, maximum=maximum, active=active, **kwargs
+        )
 
     async def _watch_worker_status(self, comm):
         # We don't want to hold on to a ref to self, otherwise this will

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 
 import pytest
 import dask
@@ -217,6 +218,40 @@ async def test_client_reprs(tmpdir):
             # HTML repr with no dashboard
             cluster.dashboard_link = None
             assert "Not Available" in cluster._repr_html_()
+
+
+@pytest.mark.asyncio
+async def test_cluster_widget(tmpdir):
+    pytest.importorskip("ipywidgets")
+
+    def test():
+        with GatewayCluster(
+            address=gateway_proc.public_urls.connect_url,
+            proxy_address=gateway_proc.gateway_urls.connect_url,
+        ) as cluster:
+            # Smoke test widget
+            cluster._widget()
+
+            template = "<tr><th>Workers</th> <td>%d</td></tr>"
+            assert (template % 0) in cluster._widget_status()
+
+            cluster.scale(1)
+            timeout = time.time() + 30
+            while time.time() < timeout:
+                if cluster.scheduler_info.get("workers"):
+                    break
+                time.sleep(0.25)
+            else:
+                assert False, "didn't scale up in time"
+
+            assert (template % 1) in cluster._widget_status()
+
+    async with temp_gateway(
+        cluster_manager_class=InProcessClusterManager,
+        temp_dir=str(tmpdir.join("dask-gateway")),
+    ) as gateway_proc:
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, test)
 
 
 @pytest.mark.asyncio

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -250,7 +250,7 @@ async def test_cluster_widget(tmpdir):
         cluster_manager_class=InProcessClusterManager,
         temp_dir=str(tmpdir.join("dask-gateway")),
     ) as gateway_proc:
-        loop = asyncio.get_running_loop()
+        loop = get_running_loop()
         await loop.run_in_executor(None, test)
 
 

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -881,10 +881,11 @@ async def test_adaptive_scaling(tmpdir):
     # XXX: we should be able to use `InProcessClusterManager` here, but due to
     # https://github.com/dask/distributed/issues/3251 this results in periodic
     # failures.
-    async with temp_gateway(
-        cluster_manager_class=LocalTestingClusterManager,
-        temp_dir=str(tmpdir.join("dask-gateway")),
-    ) as gateway_proc:
+    config = Config()
+    config.DaskGateway.cluster_manager_class = LocalTestingClusterManager
+    config.DaskGateway.temp_dir = str(tmpdir.join("dask-gateway"))
+    config.LocalTestingClusterManager.adaptive_period = 0.25
+    async with temp_gateway(config=config) as gateway_proc:
         async with Gateway(
             address=gateway_proc.public_urls.connect_url,
             proxy_address=gateway_proc.gateway_urls.connect_url,

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -38,8 +38,8 @@ async def web_proxy():
 @pytest.fixture
 async def cluster_and_security(tmpdir):
     tls_cert, tls_key = new_keypair("temp")
-    tls_key_path = tmpdir.join("dask.pem")
-    tls_cert_path = tmpdir.join("dask.crt")
+    tls_key_path = str(tmpdir.join("dask.pem"))
+    tls_cert_path = str(tmpdir.join("dask.crt"))
     with open(tls_key_path, "wb") as f:
         f.write(tls_key)
     with open(tls_cert_path, "wb") as f:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,7 +4,14 @@ import socket
 import pytest
 from traitlets import HasTraits, TraitError
 
-from dask_gateway_server.utils import Type, timeout, format_bytes, classname, ServerUrls
+from dask_gateway_server.utils import (
+    Type,
+    timeout,
+    format_bytes,
+    classname,
+    ServerUrls,
+    nullcontext,
+)
 
 
 def test_Type_traitlet():
@@ -114,3 +121,15 @@ class Foo(object):
 
 def test_classname():
     assert classname(Foo) == f"{Foo.__module__}.Foo"
+
+
+@pytest.mark.asyncio
+async def test_nullcontext():
+    async with nullcontext(0) as c:
+        assert c == 0
+
+    with nullcontext(0) as c:
+        assert c == 0
+
+    with nullcontext() as c:
+        assert c is None


### PR DESCRIPTION
Adds adaptive scaling support. For the user, this looks like:

```python
# Enable adaptive scaling
cluster.adapt()
# optionally setting min/max limits
cluster.adapt(minimum=2, maximum=10)

# An explicit scaling operation will result in adaptive scaling being turned off
cluster.scale(2)

# Or you can explicitly disable adaptive scaling
cluster.adapt(active=False)
```

Unlike other cluster managers, the implementation in dask-gateway runs the adaptive logic on the scheduler (not on the client). This allows submit-and-forget workloads where the scheduler gets the request, processes it (scaling up/down as required), with no need for a concurrently connected client. This also leaves open the option for admin-mandated adaptive scaling, which is something pangeo has asked for in the past (note this is not currently implemented here).

Administrators can configure the adaptive scaling check period by setting:

```python
c.ClusterManager.adaptive_period = 5   # period in seconds
```

A smaller period will result in decreased latency when responding to cluster load changes, but may increase the number of api calls to the gateway. The default is 3 seconds, which should be sufficient for interactive use.

This also fixes an existing bug in scale-down behavior (Fixes #157).