### PR TITLE
Allow dashboard and REST addresses to differ

### DIFF
--- a/dask-gateway/dask_gateway/gateway.yaml
+++ b/dask-gateway/dask_gateway/gateway.yaml
@@ -3,6 +3,12 @@ gateway:
                         # May also be a template string, which will be formatted
                         # with any environment variables before usage.
 
+  public-address: null  # The address to the dask-gateway server, as accessible
+                        # from a web browser. This will be used as the root of
+                        # all browser-facing links (e.g. the dask dashboard).
+                        # If `None` (default), `gateway.address` will be used.
+                        # May be a template string.
+
   proxy-address: 8786   # The full address or port to the dask-gateway
                         # scheduler proxy. If a port, the host/ip is taken from
                         # ``address``. May also be a template string.


### PR DESCRIPTION
This adds configuration to distinguish between the address the python
client should interact at from the address used when formatting
user-facing links.

This can be useful when running in an environment where the client
process should access the dask-gateway server at a different address
than the user's browser (e.g. in a JupyterHub setup, where Python
kernels are remote).

For example, if dask-gateway should be accessed behind JupyterHub's
proxy when outside the cluster, the user-side configuration would look
like:

```yaml
gateway:
  public-address: /services/dask-gateway/
  # ...
```

For now this is a configuration-only field, as I don't expect it to be
used by most users.