### PR TITLE
Update traitlets sphinx extension

### DIFF
--- a/docs/source/api-server.rst
+++ b/docs/source/api-server.rst
@@ -7,42 +7,6 @@ Gateway
 .. autoconfigurable:: dask_gateway_server.app.DaskGateway
 
 
-Cluster Manager Options
------------------------
-
-.. autoclass:: dask_gateway_server.options.Options
-
-.. autoclass:: dask_gateway_server.options.Integer
-
-.. autoclass:: dask_gateway_server.options.Float
-
-.. autoclass:: dask_gateway_server.options.String
-
-.. autoclass:: dask_gateway_server.options.Bool
-
-.. autoclass:: dask_gateway_server.options.Select
-
-
-User Limits
------------
-
-.. autoconfigurable:: dask_gateway_server.limits.UserLimits
-
-
-Proxies
--------
-
-Web Proxy
-^^^^^^^^^
-
-.. autoconfigurable:: dask_gateway_server.proxy.WebProxy
-
-Scheduler Proxy
-^^^^^^^^^^^^^^^
-
-.. autoconfigurable:: dask_gateway_server.proxy.SchedulerProxy
-
-
 Authentication
 --------------
 
@@ -51,7 +15,13 @@ Kerberos
 
 .. autoconfigurable:: dask_gateway_server.auth.KerberosAuthenticator
 
-Basic
+JupyterHub
+^^^^^^^^^^
+
+.. autoconfigurable:: dask_gateway_server.auth.JupyterHubAuthenticator
+
+
+Dummy
 ^^^^^
 
 .. autoconfigurable:: dask_gateway_server.auth.DummyAuthenticator
@@ -108,3 +78,39 @@ SlurmClusterManager
 ~~~~~~~~~~~~~~~~~~~
 
 .. autoconfigurable:: dask_gateway_server.managers.jobqueue.slurm.SlurmClusterManager
+
+
+Proxies
+-------
+
+Web Proxy
+^^^^^^^^^
+
+.. autoconfigurable:: dask_gateway_server.proxy.WebProxy
+
+Scheduler Proxy
+^^^^^^^^^^^^^^^
+
+.. autoconfigurable:: dask_gateway_server.proxy.SchedulerProxy
+
+
+Cluster Manager Options
+-----------------------
+
+.. autoclass:: dask_gateway_server.options.Options
+
+.. autoclass:: dask_gateway_server.options.Integer
+
+.. autoclass:: dask_gateway_server.options.Float
+
+.. autoclass:: dask_gateway_server.options.String
+
+.. autoclass:: dask_gateway_server.options.Bool
+
+.. autoclass:: dask_gateway_server.options.Select
+
+
+User Limits
+-----------
+
+.. autoconfigurable:: dask_gateway_server.limits.UserLimits


### PR DESCRIPTION
Updates the traitlets sphinx extension to more cleanly present
configuration options. Configuration options now:

- Are displayed using their canonical configuration names
- Have their default values displayed as an annotation, possible line
wrapped (rather than going off the edge of the docs)
- Generate reference links, which can be cross-ref'd using the `:data:`
directive.

[skip-tests]