### PR TITLE
Handle empty path in web proxy

### DIFF
--- a/dask-gateway-server/dask-gateway-proxy/router.go
+++ b/dask-gateway-server/dask-gateway-proxy/router.go
@@ -8,7 +8,7 @@ import (
 
 func normalizePath(path string) (string, int) {
 	offset := 0
-	if path == "/" {
+	if path == "" || path == "/" {
 		return "", offset
 	}
 	if path[0] == '/' {

--- a/dask-gateway-server/dask-gateway-proxy/router_test.go
+++ b/dask-gateway-server/dask-gateway-proxy/router_test.go
@@ -10,6 +10,7 @@ import (
 func TestEmpty(t *testing.T) {
 	router := NewRouter()
 	// No matches for empty router
+	assert.False(t, router.HasMatch(""))
 	assert.False(t, router.HasMatch("/"))
 	assert.False(t, router.HasMatch("/foo"))
 }
@@ -41,6 +42,9 @@ func TestMatch(t *testing.T) {
 	testMatch("/foo/val/b", bV, "")
 
 	testMatch("/foo/c", cV, "")
+
+	assert.False(t, r.HasMatch(""))
+	assert.False(t, r.HasMatch("/"))
 
 	assert.False(t, r.HasMatch("/foo/d"))
 	u, p := r.Match("/foo/d")


### PR DESCRIPTION
Previously we didn't properly handle empty paths in requests to the web proxy. We now check for this.

Fixes part of #167.