### PR TITLE
Remove global temporary directory

### DIFF
--- a/dask-gateway-server/dask_gateway_server/managers/base.py
+++ b/dask-gateway-server/dask_gateway_server/managers/base.py
@@ -135,7 +135,7 @@ class ClusterManager(LoggingConfigurable):
     # Common parameters forwarded by gateway application
     task_pool = Instance(TaskPool, args=())
     api_url = Unicode()
-    temp_dir = Unicode()
+    temp_dir = Unicode(allow_none=True)
 
     def get_tls_paths(self):
         """Get the absolute paths to the tls cert and key files."""

--- a/dask-gateway-server/dask_gateway_server/managers/yarn.py
+++ b/dask-gateway-server/dask_gateway_server/managers/yarn.py
@@ -208,7 +208,9 @@ class YarnClusterManager(ClusterManager):
             dir=self.temp_dir
         ) as key_fil:
             cert_fil.write(self.tls_cert)
+            cert_fil.file.flush()
             key_fil.write(self.tls_key)
+            key_fil.file.flush()
             yield cert_fil.name, key_fil.name
 
     @property

--- a/dask-gateway-server/dask_gateway_server/managers/yarn.py
+++ b/dask-gateway-server/dask_gateway_server/managers/yarn.py
@@ -1,7 +1,7 @@
 import asyncio
-import os
 from collections import OrderedDict
 from contextlib import contextmanager
+from tempfile import NamedTemporaryFile
 
 try:
     import skein
@@ -204,21 +204,12 @@ class YarnClusterManager(ClusterManager):
         -------
         cert_path, key_path
         """
-        prefix = os.path.join(self.temp_dir, self.cluster_name)
-        cert_path = prefix + ".crt"
-        key_path = prefix + ".pem"
-
-        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
-        try:
-            for path, data in [(cert_path, self.tls_cert), (key_path, self.tls_key)]:
-                with os.fdopen(os.open(path, flags, 0o600), "wb") as fil:
-                    fil.write(data)
-
-            yield cert_path, key_path
-        finally:
-            for path in [cert_path, key_path]:
-                if os.path.exists(path):
-                    os.unlink(path)
+        with NamedTemporaryFile(dir=self.temp_dir) as cert_fil, NamedTemporaryFile(
+            dir=self.temp_dir
+        ) as key_fil:
+            cert_fil.write(self.tls_cert)
+            key_fil.write(self.tls_key)
+            yield cert_fil.name, key_fil.name
 
     @property
     def worker_command_list(self):

--- a/dask-gateway-server/dask_gateway_server/utils.py
+++ b/dask-gateway-server/dask_gateway_server/utils.py
@@ -1,5 +1,4 @@
 import asyncio
-import shutil
 import socket
 import weakref
 from urllib.parse import urlparse
@@ -196,14 +195,6 @@ class ServerUrls(object):
         If listening on all interfaces, logs both localhost and hostname"""
         url = self.connect if self._connect_specified else self.bind
         return [u.geturl() for u in self._resolve_urls(url)]
-
-
-def cleanup_tmpdir(log, path):
-    try:
-        log.debug("Removing temporary directory %r", path)
-        shutil.rmtree(path)
-    except Exception as exc:
-        log.error("Failed to remove temporary directory %r.", path, exc_info=exc)
 
 
 async def cancel_task(task):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -39,7 +39,7 @@ def kdestroy():
 
 @pytest.mark.asyncio
 async def test_basic_auth(tmpdir):
-    async with temp_gateway(temp_dir=str(tmpdir.join("dask-gateway"))) as gateway_proc:
+    async with temp_gateway(temp_dir=str(tmpdir)) as gateway_proc:
         async with Gateway(
             address=gateway_proc.public_urls.connect_url,
             proxy_address=gateway_proc.gateway_urls.connect_url,
@@ -52,7 +52,7 @@ async def test_basic_auth(tmpdir):
 @pytest.mark.asyncio
 async def test_basic_auth_password(tmpdir):
     config = Config()
-    config.DaskGateway.temp_dir = str(tmpdir.join("dask-gateway"))
+    config.DaskGateway.temp_dir = str(tmpdir)
     config.DaskGateway.authenticator_class = (
         "dask_gateway_server.auth.DummyAuthenticator"
     )
@@ -80,7 +80,7 @@ async def test_basic_auth_password(tmpdir):
 async def test_kerberos_auth(tmpdir):
     config = Config()
     config.DaskGateway.public_url = "http://master.example.com:0"
-    config.DaskGateway.temp_dir = str(tmpdir.join("dask-gateway"))
+    config.DaskGateway.temp_dir = str(tmpdir)
     config.DaskGateway.authenticator_class = (
         "dask_gateway_server.auth.KerberosAuthenticator"
     )
@@ -158,7 +158,7 @@ async def test_jupyterhub_auth(tmpdir, monkeypatch):
     # Configure gateway
     config = Config()
     config.DaskGateway.public_url = gateway_address + "/services/dask-gateway/"
-    config.DaskGateway.temp_dir = str(tmpdir.join("dask-gateway"))
+    config.DaskGateway.temp_dir = str(tmpdir)
     config.DaskGateway.authenticator_class = (
         "dask_gateway_server.auth.JupyterHubAuthenticator"
     )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -200,8 +200,7 @@ async def test_client_fetch_timeout():
 @pytest.mark.asyncio
 async def test_client_reprs(tmpdir):
     async with temp_gateway(
-        cluster_manager_class=InProcessClusterManager,
-        temp_dir=str(tmpdir.join("dask-gateway")),
+        cluster_manager_class=InProcessClusterManager, temp_dir=str(tmpdir)
     ) as gateway_proc:
         async with Gateway(
             address=gateway_proc.public_urls.connect_url,
@@ -253,8 +252,7 @@ async def test_cluster_widget(tmpdir):
             assert (template % 1) in cluster._widget_status()
 
     async with temp_gateway(
-        cluster_manager_class=InProcessClusterManager,
-        temp_dir=str(tmpdir.join("dask-gateway")),
+        cluster_manager_class=InProcessClusterManager, temp_dir=str(tmpdir)
     ) as gateway_proc:
         loop = get_running_loop()
         await loop.run_in_executor(None, test)
@@ -265,8 +263,7 @@ async def test_dashboard_link_from_public_address(tmpdir):
     pytest.importorskip("bokeh")
 
     async with temp_gateway(
-        cluster_manager_class=InProcessClusterManager,
-        temp_dir=str(tmpdir.join("dask-gateway")),
+        cluster_manager_class=InProcessClusterManager, temp_dir=str(tmpdir)
     ) as gateway_proc:
         with dask.config.set(
             gateway__address=gateway_proc.public_urls.connect_url,
@@ -289,8 +286,7 @@ async def test_dashboard_link_from_public_address(tmpdir):
 @pytest.mark.asyncio
 async def test_create_cluster_with_GatewayCluster_constructor(tmpdir):
     async with temp_gateway(
-        cluster_manager_class=InProcessClusterManager,
-        temp_dir=str(tmpdir.join("dask-gateway")),
+        cluster_manager_class=InProcessClusterManager, temp_dir=str(tmpdir)
     ) as gateway_proc:
         async with GatewayCluster(
             address=gateway_proc.public_urls.connect_url,
@@ -324,8 +320,7 @@ async def test_create_cluster_with_GatewayCluster_constructor(tmpdir):
 @pytest.mark.asyncio
 async def test_GatewayCluster_shutdown_on_close(tmpdir):
     async with temp_gateway(
-        cluster_manager_class=InProcessClusterManager,
-        temp_dir=str(tmpdir.join("dask-gateway")),
+        cluster_manager_class=InProcessClusterManager, temp_dir=str(tmpdir)
     ) as gateway_proc:
 
         def test():
@@ -354,8 +349,7 @@ async def test_GatewayCluster_shutdown_on_close(tmpdir):
 @pytest.mark.asyncio
 async def test_GatewayCluster_cleanup_atexit(tmpdir):
     async with temp_gateway(
-        cluster_manager_class=InProcessClusterManager,
-        temp_dir=str(tmpdir.join("dask-gateway")),
+        cluster_manager_class=InProcessClusterManager, temp_dir=str(tmpdir)
     ) as gateway_proc:
 
         def test():

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -183,7 +183,7 @@ async def test_shutdown_on_startup_error(tmpdir):
         gateway_url="tls://127.0.0.1:0",
         private_url="http://127.0.0.1:0",
         public_url="http://127.0.0.1:0",
-        temp_dir=str(tmpdir.join("dask-gateway")),
+        temp_dir=str(tmpdir),
         tls_cert=str(tmpdir.join("tls_cert.pem")),
         authenticator_class="dask_gateway_server.auth.DummyAuthenticator",
     )
@@ -199,7 +199,7 @@ def test_db_encrypt_keys_required(tmpdir):
             gateway_url="tls://127.0.0.1:0",
             private_url="http://127.0.0.1:0",
             public_url="http://127.0.0.1:0",
-            temp_dir=str(tmpdir.join("dask-gateway")),
+            temp_dir=str(tmpdir),
             db_url="sqlite:///%s" % tmpdir.join("dask_gateway.sqlite"),
             authenticator_class="dask_gateway_server.auth.DummyAuthenticator",
         )
@@ -214,7 +214,7 @@ def test_db_encrypt_keys_invalid(tmpdir):
             gateway_url="tls://127.0.0.1:0",
             private_url="http://127.0.0.1:0",
             public_url="http://127.0.0.1:0",
-            temp_dir=str(tmpdir.join("dask-gateway")),
+            temp_dir=str(tmpdir),
             db_url="sqlite:///%s" % tmpdir.join("dask_gateway.sqlite"),
             db_encrypt_keys=["abc"],
             authenticator_class="dask_gateway_server.auth.DummyAuthenticator",
@@ -238,7 +238,7 @@ def test_resume_clusters_forbid_in_memory_db(tmpdir):
             gateway_url="tls://127.0.0.1:0",
             private_url="http://127.0.0.1:0",
             public_url="http://127.0.0.1:0",
-            temp_dir=str(tmpdir.join("dask-gateway")),
+            temp_dir=str(tmpdir),
             db_url="sqlite://",
             stop_clusters_on_shutdown=False,
             authenticator_class="dask_gateway_server.auth.DummyAuthenticator",
@@ -266,7 +266,7 @@ async def test_slow_cluster_start(tmpdir, start_timeout, state):
 
     config = Config()
     config.DaskGateway.cluster_manager_class = SlowStartClusterManager
-    config.DaskGateway.temp_dir = str(tmpdir.join("dask-gateway"))
+    config.DaskGateway.temp_dir = str(tmpdir)
     config.SlowStartClusterManager.cluster_start_timeout = start_timeout
 
     async with temp_gateway(config=config) as gateway_proc:
@@ -295,7 +295,7 @@ async def test_slow_cluster_connect(tmpdir):
 
     config = Config()
     config.DaskGateway.cluster_manager_class = SlowStartClusterManager
-    config.DaskGateway.temp_dir = str(tmpdir.join("dask-gateway"))
+    config.DaskGateway.temp_dir = str(tmpdir)
     config.SlowStartClusterManager.cluster_start_timeout = 0.1
     config.SlowStartClusterManager.pause_time = 0
 
@@ -326,7 +326,7 @@ async def test_cluster_fails_during_start(tmpdir, fail_stage):
 
     config = Config()
     config.DaskGateway.cluster_manager_class = ClusterFailsDuringStart
-    config.DaskGateway.temp_dir = str(tmpdir.join("dask-gateway"))
+    config.DaskGateway.temp_dir = str(tmpdir)
     config.ClusterFailsDuringStart.fail_stage = fail_stage
 
     async with temp_gateway(config=config) as gateway_proc:
@@ -354,7 +354,7 @@ async def test_cluster_fails_during_start(tmpdir, fail_stage):
 async def test_cluster_fails_between_start_and_connect(tmpdir):
     config = Config()
     config.DaskGateway.cluster_manager_class = ClusterFailsBetweenStartAndConnect
-    config.DaskGateway.temp_dir = str(tmpdir.join("dask-gateway"))
+    config.DaskGateway.temp_dir = str(tmpdir)
     config.ClusterFailsBetweenStartAndConnect.cluster_status_period = 0.1
 
     async with temp_gateway(config=config) as gateway_proc:
@@ -382,7 +382,7 @@ async def test_cluster_fails_between_start_and_connect(tmpdir):
 async def test_cluster_fails_after_connect(tmpdir):
     config = Config()
     config.DaskGateway.cluster_manager_class = ClusterFailsAfterConnect
-    config.DaskGateway.temp_dir = str(tmpdir.join("dask-gateway"))
+    config.DaskGateway.temp_dir = str(tmpdir)
     config.ClusterFailsAfterConnect.cluster_status_period = 0.25
 
     async with temp_gateway(config=config) as gateway_proc:
@@ -410,7 +410,7 @@ async def test_cluster_fails_after_connect(tmpdir):
 async def test_slow_worker_start(tmpdir, start_timeout, state):
     config = Config()
     config.DaskGateway.cluster_manager_class = SlowWorkerStartClusterManager
-    config.DaskGateway.temp_dir = str(tmpdir.join("dask-gateway"))
+    config.DaskGateway.temp_dir = str(tmpdir)
     config.SlowWorkerStartClusterManager.worker_start_timeout = start_timeout
 
     async with temp_gateway(config=config) as gateway_proc:
@@ -444,7 +444,7 @@ async def test_slow_worker_start(tmpdir, start_timeout, state):
 async def test_slow_worker_connect(tmpdir):
     config = Config()
     config.DaskGateway.cluster_manager_class = SlowWorkerStartClusterManager
-    config.DaskGateway.temp_dir = str(tmpdir.join("dask-gateway"))
+    config.DaskGateway.temp_dir = str(tmpdir)
     config.SlowWorkerStartClusterManager.worker_start_timeout = 0.1
     config.SlowWorkerStartClusterManager.pause_time = 0
 
@@ -480,7 +480,7 @@ async def test_slow_worker_connect(tmpdir):
 async def test_worker_fails_during_start(tmpdir, fail_stage):
     config = Config()
     config.DaskGateway.cluster_manager_class = WorkerFailsDuringStart
-    config.DaskGateway.temp_dir = str(tmpdir.join("dask-gateway"))
+    config.DaskGateway.temp_dir = str(tmpdir)
     config.WorkerFailsDuringStart.fail_stage = fail_stage
 
     async with temp_gateway(config=config) as gateway_proc:
@@ -515,7 +515,7 @@ async def test_worker_fails_during_start(tmpdir, fail_stage):
 async def test_worker_fails_between_start_and_connect(tmpdir):
     config = Config()
     config.DaskGateway.cluster_manager_class = WorkerFailsBetweenStartAndConnect
-    config.DaskGateway.temp_dir = str(tmpdir.join("dask-gateway"))
+    config.DaskGateway.temp_dir = str(tmpdir)
     config.WorkerFailsBetweenStartAndConnect.worker_status_period = 0.1
 
     async with temp_gateway(config=config) as gateway_proc:
@@ -545,8 +545,7 @@ async def test_worker_fails_between_start_and_connect(tmpdir):
 @pytest.mark.asyncio
 async def test_worker_fails_after_connect(tmpdir):
     async with temp_gateway(
-        cluster_manager_class=WorkerFailsAfterConnect,
-        temp_dir=str(tmpdir.join("dask-gateway")),
+        cluster_manager_class=WorkerFailsAfterConnect, temp_dir=str(tmpdir)
     ) as gateway_proc:
         async with Gateway(
             address=gateway_proc.public_urls.connect_url,
@@ -574,8 +573,7 @@ async def test_worker_fails_after_connect(tmpdir):
 @pytest.mark.asyncio
 async def test_successful_cluster(tmpdir):
     async with temp_gateway(
-        cluster_manager_class=InProcessClusterManager,
-        temp_dir=str(tmpdir.join("dask-gateway")),
+        cluster_manager_class=InProcessClusterManager, temp_dir=str(tmpdir)
     ) as gateway_proc:
         async with Gateway(
             address=gateway_proc.public_urls.connect_url,
@@ -629,7 +627,7 @@ async def test_cluster_manager_options(tmpdir):
             ),
             options.Select("option_two", options=[("small", 1.5), ("large", 15)]),
         ),
-        temp_dir=str(tmpdir.join("dask-gateway")),
+        temp_dir=str(tmpdir),
     ) as gateway_proc:
         async with Gateway(
             address=gateway_proc.public_urls.connect_url,
@@ -684,7 +682,7 @@ async def test_cluster_manager_options_client_config(tmpdir, monkeypatch):
             ),
             options.Select("option_two", options=[("small", 1.5), ("large", 15)]),
         ),
-        temp_dir=str(tmpdir.join("dask-gateway")),
+        temp_dir=str(tmpdir),
     ) as gateway_proc:
         async with Gateway(
             address=gateway_proc.public_urls.connect_url,
@@ -734,8 +732,7 @@ async def test_cluster_manager_options_client_config(tmpdir, monkeypatch):
 @pytest.mark.asyncio
 async def test_gateway_stop_clusters_on_shutdown(tmpdir):
     async with temp_gateway(
-        cluster_manager_class=InProcessClusterManager,
-        temp_dir=str(tmpdir.join("dask-gateway")),
+        cluster_manager_class=InProcessClusterManager, temp_dir=str(tmpdir)
     ) as gateway_proc:
         async with Gateway(
             address=gateway_proc.public_urls.connect_url,
@@ -761,8 +758,7 @@ async def test_gateway_stop_clusters_on_shutdown(tmpdir):
 
 @pytest.mark.asyncio
 async def test_gateway_resume_clusters_after_shutdown(tmpdir):
-    temp_dir = str(tmpdir.join("dask-gateway"))
-    os.mkdir(temp_dir, mode=0o700)
+    temp_dir = str(tmpdir)
 
     db_url = "sqlite:///%s" % tmpdir.join("dask_gateway.sqlite")
     db_encrypt_keys = [Fernet.generate_key()]
@@ -844,7 +840,7 @@ async def test_gateway_resume_clusters_after_shutdown(tmpdir):
 async def test_user_limits(tmpdir):
     config = Config()
     config.DaskGateway.cluster_manager_class = InProcessClusterManager
-    config.DaskGateway.temp_dir = str(tmpdir.join("dask-gateway"))
+    config.DaskGateway.temp_dir = str(tmpdir)
     config.UserLimits.max_clusters = 1
     config.UserLimits.max_cores = 3
     config.InProcessClusterManager.scheduler_cores = 1
@@ -894,7 +890,7 @@ async def wait_for_workers(cluster, atleast=None, exact=None, timeout=30):
 async def test_scaling(tmpdir):
     config = Config()
     config.DaskGateway.cluster_manager_class = InProcessClusterManager
-    config.DaskGateway.temp_dir = str(tmpdir.join("dask-gateway"))
+    config.DaskGateway.temp_dir = str(tmpdir)
     async with temp_gateway(config=config) as gateway_proc:
         async with Gateway(
             address=gateway_proc.public_urls.connect_url,
@@ -920,7 +916,7 @@ async def test_adaptive_scaling(tmpdir):
     # failures.
     config = Config()
     config.DaskGateway.cluster_manager_class = LocalTestingClusterManager
-    config.DaskGateway.temp_dir = str(tmpdir.join("dask-gateway"))
+    config.DaskGateway.temp_dir = str(tmpdir)
     config.LocalTestingClusterManager.adaptive_period = 0.25
     async with temp_gateway(config=config) as gateway_proc:
         async with Gateway(


### PR DESCRIPTION
This removes the use of a global temporary directory for storing any
temporary runtime files. Previously we'd always create a single root
temporary directory, and use that for all temporary files. This led to
problems, as the OS could remove the temporary directory after a long
idle server time. We now rely on the OS's facilities for creating
shortlived temporary directories/files, while still exposing
configuration for where any temporary directories may be created
(usually unnecessary). Since the lifetime of clusters is relatively
short (and usually clusters are active during their lifetime), the OS
shouldn't cleanup the temporary directory while it's still in use.

We currently use temporary directories in the following cases:

- Holding TLS credentials before forwarding to YARN (very short lived,
only needed since we can't currently upload to HDFS from memory).

- Default location for cluster working directories when running locally.
This location can be configured by setting
``c.LocalClusterManager.clusters_directory``, it's only in the default
mode when a temporary directory is created.

Fixes #167.