### PR TITLE
Add docs on admin-side cluster options

### DIFF
--- a/dask-gateway-server/dask_gateway_server/app.py
+++ b/dask-gateway-server/dask_gateway_server/app.py
@@ -166,7 +166,9 @@ class DaskGateway(Application):
         User options for configuring the cluster manager.
 
         Allows users to specify configuration overrides when creating a new
-        cluster manager. See the documentation for more information.
+        cluster manager. See the documentation for more information:
+
+        :doc:`cluster-options`.
         """,
         config=True,
     )

--- a/dask-gateway/dask_gateway/client.py
+++ b/dask-gateway/dask_gateway/client.py
@@ -448,7 +448,7 @@ class Gateway(object):
 
         Returns
         -------
-        cluster_options : Options
+        cluster_options : dask_gateway.options.Options
             A dict of cluster options.
         """
         return self.sync(
@@ -486,7 +486,7 @@ class Gateway(object):
 
         Parameters
         ----------
-        cluster_options : Options, optional
+        cluster_options : dask_gateway.options.Options, optional
             An ``Options`` object describing the desired cluster configuration.
         **kwargs :
             Additional cluster configuration options. If ``cluster_options`` is
@@ -564,7 +564,7 @@ class Gateway(object):
 
         Parameters
         ----------
-        cluster_options : Options, optional
+        cluster_options : dask_gateway.options.Options, optional
             An ``Options`` object describing the desired cluster configuration.
         shutdown_on_close : bool, optional
             If True (default), the cluster will be automatically shutdown on

--- a/docs/source/api-server.rst
+++ b/docs/source/api-server.rst
@@ -30,6 +30,15 @@ Dummy
 Cluster Managers
 ----------------
 
+Base Class
+^^^^^^^^^^
+
+ClusterManager
+~~~~~~~~~~~~~~
+
+.. autoconfigurable:: dask_gateway_server.managers.base.ClusterManager
+
+
 Local Processes
 ^^^^^^^^^^^^^^^
 
@@ -94,6 +103,12 @@ Scheduler Proxy
 .. autoconfigurable:: dask_gateway_server.proxy.SchedulerProxy
 
 
+User Limits
+-----------
+
+.. autoconfigurable:: dask_gateway_server.limits.UserLimits
+
+
 Cluster Manager Options
 -----------------------
 
@@ -108,9 +123,3 @@ Cluster Manager Options
 .. autoclass:: dask_gateway_server.options.Bool
 
 .. autoclass:: dask_gateway_server.options.Select
-
-
-User Limits
------------
-
-.. autoconfigurable:: dask_gateway_server.limits.UserLimits

--- a/docs/source/cluster-options.rst
+++ b/docs/source/cluster-options.rst
@@ -1,0 +1,159 @@
+Exposing Cluster Options
+========================
+
+By default cluster configuration (e.g. worker memory, docker image, etc...) is
+set statically by an administrator in the server configuration file. To allow
+users to change certain parameters when creating a new cluster an administrator
+must explicitly expose them in the configuration.
+
+User Experience
+---------------
+
+On the user side, exposing options with allows users to:
+
+- Query what options (if any) are available using
+  :meth:`dask_gateway.Gateway.cluster_options`
+
+.. code-block:: python
+
+    >>> options = gateway.cluster_options()
+    >>> options
+    Options<worker_cores=1, worker_memory=1.0, environment='basic'>
+
+- Specify configuration overrides for exposed fields as keyword
+  arguments to :meth:`dask_gateway.Gateway.new_cluster` or
+  :meth:`dask_gateway.GatewayCluster`.
+
+.. code-block:: python
+
+    # Using Gateway.new_cluster
+    >>> cluster = gateway.new_cluster(worker_cores=2, environment="tensorflow")
+
+    # Or using the GatewayCluster constructor
+    >>> cluster = GatewayCluster(worker_cores=2, environment="tensorflow")
+
+
+- If working in a notebook, use the ipywidgets_ based GUI to configure a
+  cluster.
+
+.. image:: /_images/options-widget.png
+    :alt: Cluster options widget
+
+
+See :ref:`user-cluster-options` for more information on the user experience.
+
+
+Server Configuration
+--------------------
+
+Options are exposed to the user by setting
+:data:`c.DaskGateway.cluster_manager_options`. This configuration field takes
+a :class:`dask_gateway_server.options.Options` object, which describes what
+options are exposed to end users, and how the gateway server should interpret
+those options.
+
+.. autosummary:: ~dask_gateway_server.options.Options
+
+A :class:`dask_gateway_server.options.Options` object takes two arguments:
+
+- ``*fields``: One or more :class:`dask_gateway_server.options.Field` objects,
+  which provide a typed declarative specification of each user facing option.
+
+- ``handler``: An optional handler function for translating the values set by
+  those options into configuration values to set on the
+  :class:`dask_gateway_server.managers.ClusterManager`.
+
+``Field`` objects provide typed specifications for a user facing option. There
+are several different ``Field`` classes available, each representing a
+different common type:
+
+.. autosummary::
+    ~dask_gateway_server.options.Integer
+    ~dask_gateway_server.options.Float
+    ~dask_gateway_server.options.Bool
+    ~dask_gateway_server.options.String
+    ~dask_gateway_server.options.Select
+
+Each field supports the following standard parameters:
+
+- ``field``: The field name to use. Must be a valid Python identifier. This
+  will be the keyword users use to set this field programmatically (e.g.
+  ``"worker_cores"``).
+- ``default``: The default value if the user doesn't specify this field.
+- ``label``: A human readable label that will be used in GUI representations
+  (e.g. ``"Worker Cores"``). Optional, if not provided ``field`` will be used.
+- ``target``: The target key to set in the processed options dict. Must be a
+  valid Python identifier. Optional, if not provided ``field`` will be used.
+
+After validation (type, bounds, etc...), a dictionary of all options for a
+requested cluster is passed to a ``handler`` function. Here any additional
+validation can be done (errors raised in the handler are forwarded to the
+user), as well as any conversion needed between the exposed option fields and
+configuration fields on the backing
+:class:`dask_gateway_server.managers.ClusterManager`. The default ``handler``
+returns the provided options unchanged.
+
+Examples
+--------
+
+Worker Cores and Memory
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Here we expose options for users to configure
+:data:`c.ClusterManager.worker_cores` and
+:data:`c.ClusterManager.worker_memory`. We set bounds on each resource to
+prevent users from requesting too large of a worker. The handler is used to
+convert the user specified memory from GiB to bytes (as expected by
+:data:`c.ClusterManager.worker_memory`).
+
+.. code-block:: python
+
+    from dask_gateway_server.options import Options, Integer, Float
+
+    def options_handler(options):
+        return {
+            "worker_cores": options.worker_cores,
+            "worker_memory": int(options.worker_memory * 2 ** 30),
+        }
+
+    c.DaskGateway.cluster_manager_options = Options(
+        Integer("worker_cores", default=1, min=1, max=4, label="Worker Cores"),
+        Float("worker_memory", default=1, min=1, max=8, label="Worker Memory (GiB)"),
+        handler=options_handler,
+    )
+
+
+Cluster Profiles
+^^^^^^^^^^^^^^^^
+
+Instead of exposing individual options, you may instead wish to expose
+"profiles" - user-friendly names for common groups of options. For example,
+here we provide 3 cluster profiles (small, medium, and large) a user can select
+from.
+
+.. code-block:: python
+
+    from dask_gateway_server.options import Options, Select
+
+    # A mapping from profile name to configuration overrides
+    profiles = {
+        "small": {"worker_cores": 2, "worker_memory": "4 G"},
+        "medium": {"worker_cores": 4, "worker_memory": "8 G"},
+        "large": {"worker_cores": 8, "worker_memory": "16 G"},
+    }
+
+    # Expose `profile` as an option, valid values are 'small', 'medium', or
+    # 'large'. A handler is used to convert the profile name to the
+    # corresponding configuration overrides.
+    c.DaskGateway.cluster_manager_options = Options(
+        Select(
+            "profile",
+            ["small", "medium", "large"],
+            default="medium",
+            label="Cluster Profile",
+        )
+        handler=lambda options: profiles[options.profile],
+    )
+
+
+.. _ipywidgets: https://ipywidgets.readthedocs.io/en/latest/

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -20,6 +20,7 @@ docs = os.path.dirname(os.path.dirname(__file__))
 sys.path.insert(0, os.path.join(docs, "sphinxext"))
 extensions = [
     "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
     "sphinx.ext.extlinks",
     "sphinx.ext.napoleon",
     "autodoc_traitlets",

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -64,17 +64,6 @@ both the cluster backend and the authentication protocol are pluggable.
 - Basic (for testing only)
 
 
-Installation
-------------
-
-As Dask-Gateway can be installed in many different environments, we provide
-instructions for a few different setups.
-
-- :doc:`install-local`
-- :doc:`install-hadoop`
-- :doc:`install-kube`
-
-
 .. toctree::
    :maxdepth: 1
    :hidden:
@@ -87,11 +76,18 @@ instructions for a few different setups.
 .. toctree::
    :maxdepth: 1
    :hidden:
-   :caption: For Administrators
+   :caption: Admin - Installation
 
    install-local
    install-hadoop
    install-kube
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+   :caption: Admin - Customization
+
+   cluster-options
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -96,6 +96,9 @@ with the gateway server only to create a new cluster then using
 instead.
 
 
+.. _user-cluster-options:
+
+
 Configure a cluster
 -------------------
 


### PR DESCRIPTION
Add admin facing docs on exposing cluster options to users. Also does a
bit of reorganizing.