### PR TITLE
Add cluster idle timeout

### DIFF
--- a/dask-gateway-server/dask_gateway_server/handlers.py
+++ b/dask-gateway-server/dask_gateway_server/handlers.py
@@ -202,7 +202,7 @@ class ClustersHandler(BaseHandler):
                     return
         self.write(cluster_model(self.gateway, cluster, full=True))
 
-    @authenticated(user=True)
+    @authenticated(user=True, token=True)
     async def delete(self, cluster_name):
         # Only accept urls of the form /api/clusters/{cluster_name}
         if not cluster_name:

--- a/dask-gateway-server/dask_gateway_server/managers/base.py
+++ b/dask-gateway-server/dask_gateway_server/managers/base.py
@@ -112,6 +112,17 @@ class ClusterManager(LoggingConfigurable):
         config=True,
     )
 
+    idle_timeout = Float(
+        0,
+        min=0,
+        help="""
+        Time (in seconds) before an idle cluster is automatically shutdown.
+
+        Set to 0 (default) for no idle timeout.
+        """,
+        config=True,
+    )
+
     adaptive_period = Float(
         3,
         min=0,
@@ -171,7 +182,13 @@ class ClusterManager(LoggingConfigurable):
     @property
     def scheduler_command_list(self):
         """The full command (as an arg list) to launch a dask scheduler"""
-        return [self.scheduler_cmd, "--adaptive-period", str(self.adaptive_period)]
+        return [
+            self.scheduler_cmd,
+            "--adaptive-period",
+            str(self.adaptive_period),
+            "--idle-timeout",
+            str(self.idle_timeout),
+        ]
 
     @property
     def worker_command(self):

--- a/dask-gateway-server/dask_gateway_server/managers/inprocess.py
+++ b/dask-gateway-server/dask_gateway_server/managers/inprocess.py
@@ -36,6 +36,7 @@ class InProcessClusterManager(UnsafeLocalClusterManager):
             security,
             exit_on_failure=False,
             adaptive_period=self.adaptive_period,
+            idle_timeout=self.idle_timeout,
         )
         yield {}
 


### PR DESCRIPTION
Adds support for automatically shutting down idle clusters. The timeout
can be set by the admin, by default it's 0 for no timeout.