### PR TITLE
Set `USER` as explicit numerical `uid`

### DIFF
--- a/resources/helm/images/dask-gateway-base/Dockerfile
+++ b/resources/helm/images/dask-gateway-base/Dockerfile
@@ -38,7 +38,7 @@ RUN useradd -m -U -u 1000 dask \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-USER dask:dask
+USER 1000:1000
 ENV PATH="/opt/conda/bin:$PATH"
 WORKDIR /home/dask/
 

--- a/resources/helm/images/dask-gateway-server/Dockerfile
+++ b/resources/helm/images/dask-gateway-server/Dockerfile
@@ -10,5 +10,5 @@ USER root
 WORKDIR /srv/dask-gateway
 RUN chown dask:dask /srv/dask-gateway
 
-USER dask:dask
+USER 1000:1000
 CMD ["dask-gateway-server", "--config", "/etc/dask-gateway/dask_gateway_config.py"]


### PR DESCRIPTION
I've looked at the Dockerfiles and they all run as user dask with uid
1000 -- the issue is that K8s has trouble figuring out if a non-numeric
user is a root or not.

For users in enterprise settings with locked down clusters, (specifically, 
a podSecurityPolicy that prevents containers from running as root) there 
are two options:

* explicitly set the `securityContext.runAsUser` in both the helm chart templates and as `extraPodConfig` for all pods
* tweak the dockerfiles to set the default user as 1000

I've tested and specifying `1000` as the `USER` instead of `dask`
doesn't change how users interact with the container (e.g. you are in
the correct `$HOME` directory, `whoami` returns `dask`, etc.) but now
K8S can correctly recognize that `dask` is a non-root user.