### PR TITLE
Fix Gateway.connect in sync mode

### DIFF
--- a/dask-gateway/dask_gateway/client.py
+++ b/dask-gateway/dask_gateway/client.py
@@ -760,8 +760,6 @@ class GatewayCluster(object):
             asynchronous=asynchronous,
             loop=loop,
         )
-        if not self.asynchronous:
-            self.gateway.sync(self._start_internal)
 
     @classmethod
     def from_name(
@@ -851,6 +849,8 @@ class GatewayCluster(object):
 
         if name is not None:
             self.status = "starting"
+        if not self.asynchronous:
+            self.gateway.sync(self._start_internal)
 
     @property
     def loop(self):


### PR DESCRIPTION
`Gateway.connect` was broken in the latest release when running in
synchronous mode. This fixes this, and adds a test for all constructors
in synchronous mode.

Fixes #181.