### PR TITLE
Add limit on worker start failures

### DIFF
--- a/dask-gateway-server/dask_gateway_server/backends/base.py
+++ b/dask-gateway-server/dask_gateway_server/backends/base.py
@@ -124,7 +124,7 @@ class Backend(LoggingConfigurable):
         Do any cleanup tasks in this method"""
         await self.session.close()
 
-    async def list_clusters(self, user=None, statuses=None):
+    async def list_clusters(self, username=None, statuses=None):
         """List known clusters.
 
         Parameters


### PR DESCRIPTION
Adds a limit on the number of subsequent worker start failures a cluster
can have (timeouts exempt). This helps catch configuration/installation
issues, and prevents an endless restart loop.

If the number of subsequent startup failures exceeds this limit, the
cluster is marked as failed and is shutdown.