### PR TITLE
Don't use `asyncio.run`

### DIFF
--- a/dask-gateway-server/dask_gateway_server/app.py
+++ b/dask-gateway-server/dask_gateway_server/app.py
@@ -12,10 +12,9 @@ from traitlets.config import Application, catch_config_error
 from . import __version__ as VERSION
 from .auth import Authenticator
 from .backends import Backend
-from .compat import asyncio_run
 from .routes import default_routes
 from .traitlets import Type
-from .utils import classname, LogFormatter, normalize_address
+from .utils import classname, LogFormatter, normalize_address, run_main
 
 
 # Override default values for logging
@@ -247,7 +246,7 @@ class DaskGateway(Application):
             return self.subapp.start()
 
         try:
-            asyncio_run(self.main())
+            run_main(self.main())
         except (KeyboardInterrupt, web.GracefulExit):
             pass
 

--- a/dask-gateway-server/dask_gateway_server/compat.py
+++ b/dask-gateway-server/dask_gateway_server/compat.py
@@ -1,52 +1,10 @@
 import sys
 
 if sys.version_info[:2] >= (3, 7):
-    from asyncio import get_running_loop, run as asyncio_run
+    from asyncio import get_running_loop, all_tasks
 else:
     import asyncio
-    from asyncio import _get_running_loop as get_running_loop
+    from asyncio import _get_running_loop as get_running_loop  # noqa
 
-    # Borrowed from https://github.com/python/cpython/blob/master/Lib/asyncio/runners.py
-    # Can be deleted once we drop 3.6 support
-
-    def asyncio_run(main):
-        if get_running_loop() is not None:
-            raise RuntimeError(
-                "asyncio.run() cannot be called from a running event loop"
-            )
-
-        loop = asyncio.new_event_loop()
-        try:
-            asyncio.set_event_loop(loop)
-            return loop.run_until_complete(main)
-        finally:
-            try:
-                _cancel_all_tasks(loop)
-                loop.run_until_complete(loop.shutdown_asyncgens())
-            finally:
-                asyncio.set_event_loop(None)
-                loop.close()
-
-    def _cancel_all_tasks(loop):
-        to_cancel = asyncio.Task.all_tasks(loop)
-        if not to_cancel:
-            return
-
-        for task in to_cancel:
-            task.cancel()
-
-        loop.run_until_complete(
-            asyncio.gather(*to_cancel, loop=loop, return_exceptions=True)
-        )
-
-        for task in to_cancel:
-            if task.cancelled():
-                continue
-            if task.exception() is not None:
-                loop.call_exception_handler(
-                    {
-                        "message": "unhandled exception during asyncio.run() shutdown",
-                        "exception": task.exception(),
-                        "task": task,
-                    }
-                )
+    def all_tasks(loop=None):
+        return {t for t in asyncio.Task.all_tasks(loop) if not t.done()}


### PR DESCRIPTION
While nice in theory, `asyncio.run` handles shutdown in a way that we
don't necessarily want. When an exception is raised in the loop (like a
`SystemExit`), all running tasks are cancelled at the same time.
Instead, we'd like to cancel the *main* task and let it handle cleaning
up child tasks. We then check if any tasks remain, cancel and log those
(lingering tasks indicate bugs/failures), and clean up the loop.