### PR TITLE
Support tcp and http proxy on same port

### DIFF
--- a/dask-gateway-server/dask-gateway-proxy/main.go
+++ b/dask-gateway-server/dask-gateway-proxy/main.go
@@ -475,12 +475,13 @@ func (p *Proxy) handleConnection(inConn *net.TCPConn, forwarder *Forwarder) {
 
 	sni, isTLS, pInConn, err := readSNI(inConn)
 	if err != nil {
-		p.logger.Infof("Error extracting SNI: %s", err)
+		p.logger.Debugf("Error extracting SNI: %s", err)
 		inConn.Close()
 		return
 	}
 
-	if !isTLS || sni == "" {
+	const sniPrefix = "daskgateway-"
+	if !isTLS || !strings.HasPrefix(sni, sniPrefix) {
 		if forwarder != nil {
 			forwarder.Forward(pInConn)
 			return
@@ -490,6 +491,8 @@ func (p *Proxy) handleConnection(inConn *net.TCPConn, forwarder *Forwarder) {
 			return
 		}
 	}
+
+	sni = sni[len(sniPrefix):]
 
 	defer inConn.Close()
 

--- a/dask-gateway-server/dask-gateway-proxy/main.go
+++ b/dask-gateway-server/dask-gateway-proxy/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bufio"
-	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -89,20 +88,18 @@ func (r *Route) Validate(full bool) error {
 }
 
 type Proxy struct {
-	tlsTimeout time.Duration
 	logger     *Logger
 	sniRoutes  map[string]string
 	router     *Router
-	proxy      *httputil.ReverseProxy
 	routesLock sync.RWMutex
+	proxy      *httputil.ReverseProxy
 }
 
-func NewProxy(tlsTimeout time.Duration, logLevel LogLevel) *Proxy {
+func NewProxy(logLevel LogLevel) *Proxy {
 	out := Proxy{
-		tlsTimeout: tlsTimeout,
-		logger:     NewLogger("Proxy", logLevel),
-		sniRoutes:  make(map[string]string),
-		router:     NewRouter(),
+		logger:    NewLogger("Proxy", logLevel),
+		sniRoutes: make(map[string]string),
+		router:    NewRouter(),
 	}
 	out.proxy = &httputil.ReverseProxy{
 		Director:      out.director,
@@ -122,12 +119,38 @@ func awaitShutdown() {
 	}
 }
 
-func (p *Proxy) run(httpAddress, tlsAddress, apiURL, apiToken, tlsCert, tlsKey string, isChildProcess bool) {
+func (p *Proxy) run(address, tcpAddress, apiURL, apiToken, tlsCert, tlsKey string, isChildProcess bool) {
 	if isChildProcess {
 		go awaitShutdown()
 	}
-	go p.runHTTP(httpAddress, tlsCert, tlsKey)
-	go p.runTLS(tlsAddress)
+
+	if tcpAddress == "" {
+		tcpAddress = address
+	}
+
+	tlsListener, err := net.Listen("tcp", tcpAddress)
+	if err != nil {
+		p.logger.Errorf("%s", err)
+		os.Exit(1)
+	}
+	p.logger.Infof("TCP Proxy serving at %s", tcpAddress)
+
+	var httpListener net.Listener
+	var forwarder *Forwarder = nil
+	if address == tcpAddress {
+		forwarder = newForwarder(tlsListener)
+		httpListener = forwarder
+	} else {
+		httpListener, err = net.Listen("tcp", address)
+		if err != nil {
+			p.logger.Errorf("%s", err)
+			os.Exit(1)
+		}
+	}
+	p.logger.Infof("HTTP Proxy serving at %s", address)
+
+	go p.runHTTP(httpListener, tlsCert, tlsKey)
+	go p.runTCP(tlsListener, forwarder)
 	p.watchRoutes(apiURL, apiToken, 15*time.Second)
 }
 
@@ -408,18 +431,15 @@ func (p *Proxy) director(req *http.Request) {
 	}
 }
 
-func (p *Proxy) runHTTP(address, tlsCert, tlsKey string) {
+func (p *Proxy) runHTTP(ln net.Listener, tlsCert, tlsKey string) {
 	server := &http.Server{
-		Addr:    address,
 		Handler: p,
 	}
 	var err error
 	if tlsCert == "" {
-		p.logger.Infof("HTTP Proxy serving at http://%s", address)
-		err = server.ListenAndServe()
+		err = server.Serve(ln)
 	} else {
-		p.logger.Infof("HTTP Proxy serving at https://%s", address)
-		err = server.ListenAndServeTLS(tlsCert, tlsKey)
+		err = server.ServeTLS(ln, tlsCert, tlsKey)
 	}
 	if err != nil && err != http.ErrServerClosed {
 		p.logger.Errorf("%s", err)
@@ -427,91 +447,78 @@ func (p *Proxy) runHTTP(address, tlsCert, tlsKey string) {
 	}
 }
 
-// TLS proxy implementation
+// TCP proxy implementation
 
-type tlsConn struct {
-	inConn   *net.TCPConn
-	outConn  *net.TCPConn
-	sni      string
-	outAddr  string
-	tlsMinor int
+type Forwarder struct {
+	net.Listener
+	conns chan net.Conn
 }
 
-type tlsAlert int8
-
-const (
-	internalError    tlsAlert = 80
-	unrecognizedName          = 112
-)
-
-func (p *Proxy) sendAlert(c *tlsConn, alert tlsAlert, format string, args ...interface{}) {
-	p.logger.Debugf(format, args...)
-
-	alertMsg := []byte{21, 3, byte(c.tlsMinor), 0, 2, 2, byte(alert)}
-
-	if err := c.inConn.SetWriteDeadline(time.Now().Add(p.tlsTimeout)); err != nil {
-		p.logger.Debugf("Error while setting write deadline during abort: %s", err)
-		return
-	}
-
-	if _, err := c.inConn.Write(alertMsg); err != nil {
-		p.logger.Debugf("Error while sending alert: %s", err)
+func newForwarder(ln net.Listener) *Forwarder {
+	return &Forwarder{
+		Listener: ln,
+		conns:    make(chan net.Conn),
 	}
 }
 
-func (p *Proxy) handleConnection(c *tlsConn) {
-	defer c.inConn.Close()
+func (h *Forwarder) Forward(conn net.Conn) {
+	h.conns <- conn
+}
 
+func (h *Forwarder) Accept() (net.Conn, error) {
+	conn := <-h.conns
+	return conn, nil
+}
+
+func (p *Proxy) handleConnection(inConn *net.TCPConn, forwarder *Forwarder) {
 	var err error
 
-	if err = c.inConn.SetReadDeadline(time.Now().Add(p.tlsTimeout)); err != nil {
-		p.sendAlert(c, internalError, "Setting read deadline for handshake: %s", err)
-		return
-	}
-
-	var handshakeBuf bytes.Buffer
-	c.sni, c.tlsMinor, err = readVerAndSNI(io.TeeReader(c.inConn, &handshakeBuf))
+	sni, isTLS, pInConn, err := readSNI(inConn)
 	if err != nil {
-		p.sendAlert(c, internalError, "Extracting SNI: %s", err)
+		p.logger.Infof("Error extracting SNI: %s", err)
+		inConn.Close()
 		return
 	}
 
-	if err = c.inConn.SetReadDeadline(time.Time{}); err != nil {
-		p.sendAlert(c, internalError, "Clearing read deadline for handshake: %s", err)
-		return
+	if !isTLS || sni == "" {
+		if forwarder != nil {
+			forwarder.Forward(pInConn)
+			return
+		} else {
+			p.logger.Debug("Invalid connection attempt, closing")
+			inConn.Close()
+			return
+		}
 	}
+
+	defer inConn.Close()
 
 	p.routesLock.RLock()
-	c.outAddr = p.sniRoutes[c.sni]
+	outAddr := p.sniRoutes[sni]
 	p.routesLock.RUnlock()
-	if c.outAddr == "" {
-		p.sendAlert(c, unrecognizedName, "SNI %q not found", c.sni)
+
+	if outAddr == "" {
+		p.logger.Infof("SNI %q not found", sni)
 		return
 	}
 
-	p.logger.Infof("SNI %q -> %q", c.sni, c.outAddr)
+	p.logger.Infof("SNI %q -> %q", sni, outAddr)
 
-	outConn, err := net.DialTimeout("tcp", c.outAddr, 10*time.Second)
+	outConn, err := net.DialTimeout("tcp", outAddr, 10*time.Second)
 	if err != nil {
-		p.sendAlert(c, internalError, "Failed to connect to destination %q: %s", c.outAddr, err)
+		p.logger.Debugf("Failed to connect to destination %q: %s", outAddr, err)
 		return
 	}
-	c.outConn = outConn.(*net.TCPConn)
-	defer c.outConn.Close()
-
-	if _, err = io.Copy(c.outConn, &handshakeBuf); err != nil {
-		p.sendAlert(c, internalError, "Failed to replay handshake to %q: %s", c.outAddr, err)
-		return
-	}
+	defer outConn.Close()
 
 	var wg sync.WaitGroup
 	wg.Add(2)
-	go p.proxyConnections(&wg, c.inConn, c.outConn)
-	go p.proxyConnections(&wg, c.outConn, c.inConn)
+	go p.proxyConnections(&wg, pInConn, outConn.(*net.TCPConn))
+	go p.proxyConnections(&wg, outConn.(*net.TCPConn), pInConn)
 	wg.Wait()
 }
 
-func (p *Proxy) proxyConnections(wg *sync.WaitGroup, in, out *net.TCPConn) {
+func (p *Proxy) proxyConnections(wg *sync.WaitGroup, in, out tcpConn) {
 	defer wg.Done()
 	if _, err := io.Copy(in, out); err != nil {
 		p.logger.Debugf("Error proxying %q -> %q: %s", in.RemoteAddr(), out.RemoteAddr(), err)
@@ -520,39 +527,31 @@ func (p *Proxy) proxyConnections(wg *sync.WaitGroup, in, out *net.TCPConn) {
 	out.CloseWrite()
 }
 
-func (p *Proxy) runTLS(tlsAddress string) {
-	p.logger.Infof("TLS Proxy serving at %s", tlsAddress)
-	l, err := net.Listen("tcp", tlsAddress)
-	if err != nil {
-		p.logger.Errorf("%s", err)
-		os.Exit(1)
-	}
+func (p *Proxy) runTCP(ln net.Listener, forwarder *Forwarder) {
 	for {
-		c, err := l.Accept()
+		c, err := ln.Accept()
 		if err != nil {
 			p.logger.Debugf("Failed to accept new connection: %s", err)
 		}
 
-		conn := &tlsConn{inConn: c.(*net.TCPConn)}
-		go p.handleConnection(conn)
+		go p.handleConnection(c.(*net.TCPConn), forwarder)
 	}
 }
 
 func main() {
 	var (
-		httpAddress    string
-		tlsAddress     string
+		address        string
+		tcpAddress     string
 		apiURL         string
 		logLevelString string
 		isChildProcess bool
 		tlsCert        string
 		tlsKey         string
-		tlsTimeout     time.Duration
 	)
 
 	command := flag.NewFlagSet("dask-gateway-proxy", flag.ExitOnError)
-	command.StringVar(&httpAddress, "address", ":8000", "HTTP proxy listening address")
-	command.StringVar(&tlsAddress, "tls-address", ":8786", "TLS proxy listening address")
+	command.StringVar(&address, "address", ":8000", "HTTP proxy listening address")
+	command.StringVar(&tcpAddress, "tcp-address", "", "TCP proxy listening address. If empty, `address` will be used.")
 	command.StringVar(&apiURL, "api-url", "", "The URL the proxy should watch for updating the routing table")
 	command.StringVar(&logLevelString, "log-level", "INFO",
 		"The log level. One of {DEBUG, INFO, WARN, ERROR}")
@@ -560,7 +559,6 @@ func main() {
 		"If set, will exit when stdin EOFs. Useful when running as a child process.")
 	command.StringVar(&tlsCert, "tls-cert", "", "TLS cert to use, if any.")
 	command.StringVar(&tlsKey, "tls-key", "", "TLS key to use, if any.")
-	command.DurationVar(&tlsTimeout, "tls-timeout", 3*time.Second, "Timeout for TLS Handshake initialization")
 
 	command.Parse(os.Args[1:])
 
@@ -582,7 +580,7 @@ func main() {
 		panic("Invalid -api-url: " + err.Error())
 	}
 
-	proxy := NewProxy(tlsTimeout, logLevel)
+	proxy := NewProxy(logLevel)
 
-	proxy.run(httpAddress, tlsAddress, apiURL, token, tlsCert, tlsKey, isChildProcess)
+	proxy.run(address, tcpAddress, apiURL, token, tlsCert, tlsKey, isChildProcess)
 }

--- a/dask-gateway-server/dask-gateway-proxy/sni.go
+++ b/dask-gateway-server/dask-gateway-proxy/sni.go
@@ -1,154 +1,81 @@
 package main
 
 import (
-	"encoding/binary"
-	"errors"
-	"fmt"
+	"bufio"
+	"bytes"
+	"crypto/tls"
 	"io"
+	"net"
 )
 
-const extensionID = 0
-const hostnameID = 0
-
-// Parses a Vector object (length prefixed bytes) per the TLS spec
-func parseVector(buf []byte, lenBytes int) ([]byte, []byte, error) {
-	if len(buf) < lenBytes {
-		return nil, nil, errors.New("Not enough space in packet for vector")
-	}
-	var l int
-	for _, b := range buf[:lenBytes] {
-		l = (l << 8) + int(b)
-	}
-	if len(buf) < l+lenBytes {
-		return nil, nil, errors.New("Not enough space in packet for vector")
-	}
-	return buf[lenBytes : l+lenBytes], buf[l+lenBytes:], nil
+type tcpConn interface {
+	net.Conn
+	CloseWrite() error
+	CloseRead() error
 }
 
-func readSNI(buf []byte) (string, error) {
-	if len(buf) == 0 {
-		return "", errors.New("Zero length handshake record")
-	}
-	if buf[0] != 1 {
-		return "", fmt.Errorf("Non-ClientHello handshake record type %d", buf[0])
-	}
-
-	buf, _, err := parseVector(buf[1:], 3)
-	if err != nil {
-		return "", fmt.Errorf("Reading ClientHello: %s", err)
-	}
-
-	if len(buf) < 34 {
-		return "", errors.New("ClientHello packet too short")
-	}
-
-	if buf[0] != 3 || buf[1] < 1 || buf[1] > 3 {
-		return "", fmt.Errorf("ClientHello has unsupported version %d.%d", buf[0], buf[1])
-	}
-
-	// Skip version and random struct
-	buf = buf[34:]
-
-	vec, buf, err := parseVector(buf, 1)
-	if err != nil {
-		return "", fmt.Errorf("Reading ClientHello SessionID: %s", err)
-	}
-	if len(vec) > 32 {
-		return "", fmt.Errorf("ClientHello SessionID too long (%db)", len(vec))
-	}
-
-	vec, buf, err = parseVector(buf, 2)
-	if err != nil {
-		return "", fmt.Errorf("Reading ClientHello CipherSuites: %s", err)
-	}
-	if len(vec) < 2 || len(vec)%2 != 0 {
-		return "", fmt.Errorf("ClientHello CipherSuites invalid length %d", len(vec))
-	}
-
-	vec, buf, err = parseVector(buf, 1)
-	if err != nil {
-		return "", fmt.Errorf("Reading ClientHello CompressionMethods: %s", err)
-	}
-	if len(vec) < 1 {
-		return "", fmt.Errorf("ClientHello CompressionMethods invalid length %d", len(vec))
-	}
-
-	if len(buf) != 0 {
-		// Check vector is proper length for remaining msg
-		vec, buf, err = parseVector(buf, 2)
-		if err != nil {
-			return "", fmt.Errorf("Reading ClientHello extensions: %s", err)
-		}
-		if len(buf) != 0 {
-			return "", fmt.Errorf("%d bytes of trailing garbage in ClientHello", len(buf))
-		}
-		buf = vec
-
-		for len(buf) >= 4 {
-			typ := binary.BigEndian.Uint16(buf[:2])
-			vec, buf, err = parseVector(buf[2:], 2)
-			if err != nil {
-				return "", fmt.Errorf("Reading ClientHello extension %d: %s", typ, err)
-			}
-			if typ == extensionID {
-				// We found an SNI extension, attempt to extract the hostname
-				buf, _, err := parseVector(vec, 2)
-				if err != nil {
-					return "", err
-				}
-
-				for len(buf) >= 3 {
-					typ := buf[0]
-					vec, buf, err = parseVector(buf[1:], 2)
-					if err != nil {
-						return "", errors.New("Truncated SNI extension")
-					}
-
-					// This vec is a hostname, return
-					if typ == hostnameID {
-						return string(vec), nil
-					}
-				}
-
-				if len(buf) != 0 {
-					return "", errors.New("Trailing garbage at end of SNI extension")
-				}
-
-				return "", nil
-			}
-		}
-	}
-	return "", errors.New("No SNI found")
+type peekedTCPConn struct {
+	peeked []byte
+	*net.TCPConn
 }
 
-func readVerAndSNI(r io.Reader) (string, int, error) {
-	var header struct {
-		Type         uint8
-		Major, Minor uint8
-		Length       uint16
+func (c *peekedTCPConn) Read(p []byte) (n int, err error) {
+	if len(c.peeked) > 0 {
+		n = copy(p, c.peeked)
+		c.peeked = c.peeked[n:]
+		if len(c.peeked) == 0 {
+			c.peeked = nil
+		}
+		return n, nil
 	}
-	if err := binary.Read(r, binary.BigEndian, &header); err != nil {
-		return "", 0, fmt.Errorf("Error reading TLS record header: %s", err)
+	return c.TCPConn.Read(p)
+}
+
+func wrapPeeked(inConn *net.TCPConn, br *bufio.Reader) tcpConn {
+	peeked, _ := br.Peek(br.Buffered())
+	return &peekedTCPConn{TCPConn: inConn, peeked: peeked}
+}
+
+type readonly struct {
+	r io.Reader
+	net.Conn
+}
+
+func (c readonly) Read(p []byte) (int, error) { return c.r.Read(p) }
+func (readonly) Write(p []byte) (int, error)  { return 0, io.EOF }
+
+func readSNI(inConn *net.TCPConn) (string, bool, tcpConn, error) {
+	br := bufio.NewReader(inConn)
+	hdr, err := br.Peek(1)
+	if err != nil {
+		return "", false, nil, err
 	}
 
-	if header.Type != 22 {
-		return "", 0, fmt.Errorf("TLS record is not a handshake")
+	if hdr[0] != 0x16 {
+		// Not a TLS handshake
+		return "", false, wrapPeeked(inConn, br), nil
 	}
 
-	if header.Major != 3 || header.Minor < 1 || header.Minor > 3 {
-		return "", 0, fmt.Errorf("TLS record has unsupported version %d.%d",
-			header.Major, header.Minor)
+	const headerLen = 5
+	hdr, err = br.Peek(headerLen)
+	if err != nil {
+		return "", false, wrapPeeked(inConn, br), nil
 	}
 
-	if header.Length > 16384 {
-		return "", 0, errors.New("TLS record is malformed")
+	recLen := int(hdr[3])<<8 | int(hdr[4])
+	helloBytes, err := br.Peek(headerLen + recLen)
+	if err != nil {
+		return "", true, wrapPeeked(inConn, br), nil
 	}
 
-	buf := make([]byte, header.Length)
-	if _, err := io.ReadFull(r, buf); err != nil {
-		return "", 0, err
-	}
+	sni := ""
+	server := tls.Server(readonly{r: bytes.NewReader(helloBytes)}, &tls.Config{
+		GetConfigForClient: func(hello *tls.ClientHelloInfo) (*tls.Config, error) {
+			sni = hello.ServerName
+			return nil, nil
+		},
+	})
+	server.Handshake()
 
-	sni, err := readSNI(buf)
-	return sni, int(header.Minor), err
+	return sni, true, wrapPeeked(inConn, br), nil
 }

--- a/dask-gateway/dask_gateway/client.py
+++ b/dask-gateway/dask_gateway/client.py
@@ -244,9 +244,10 @@ class Gateway(object):
     address : str, optional
         The address to the gateway server.
     proxy_address : str, int, optional
-        The address of the scheduler proxy server. If an int, it's used as the
-        port, with the host/ip taken from ``address``. Provide a full address
-        if a different host/ip should be used.
+        The address of the scheduler proxy server. Defaults to `address` if not
+        provided. If an int, it's used as the port, with the host/ip taken from
+        ``address``. Provide a full address if a different host/ip should be
+        used.
     auth : GatewayAuth, optional
         The authentication method to use.
     asynchronous : bool, optional
@@ -277,9 +278,7 @@ class Gateway(object):
         if proxy_address is None:
             proxy_address = format_template(dask.config.get("gateway.proxy-address"))
         if proxy_address is None:
-            raise ValueError(
-                "No dask-gateway proxy address provided or found in configuration"
-            )
+            proxy_address = address
         if isinstance(proxy_address, int):
             parsed = urlparse(address)
             proxy_netloc = "%s:%d" % (parsed.hostname, proxy_address)

--- a/dask-gateway/dask_gateway/comm.py
+++ b/dask-gateway/dask_gateway/comm.py
@@ -33,7 +33,8 @@ class GatewayConnector(Connector):
     client = TCPClient(resolver=_resolver)
 
     async def connect(self, address, deserialize=True, **connection_args):
-        ip, port, sni = parse_gateway_address(address)
+        ip, port, path = parse_gateway_address(address)
+        sni = "daskgateway-" + path
         ctx = connection_args.get("ssl_context")
         if not isinstance(ctx, ssl.SSLContext):
             raise TypeError(

--- a/dask-gateway/dask_gateway/gateway.yaml
+++ b/dask-gateway/dask_gateway/gateway.yaml
@@ -9,9 +9,10 @@ gateway:
                         # If `None` (default), `gateway.address` will be used.
                         # May be a template string.
 
-  proxy-address: 8786   # The full address or port to the dask-gateway
+  proxy-address: null   # The full address or port to the dask-gateway
                         # scheduler proxy. If a port, the host/ip is taken from
-                        # ``address``. May also be a template string.
+                        # ``address``. If null, defaults to `address`.
+                        # May also be a template string.
 
   auth:
     type: basic         # The authentication type to use. Options are basic,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -46,7 +46,7 @@ def test_proxy_cli(tmpdir, monkeypatch):
     text = (
         "c.DaskGateway.address = '127.0.0.1:8888'\n"
         "c.Proxy.address = '127.0.0.1:8866'\n"
-        "c.Proxy.scheduler_address = '127.0.0.1:8867'\n"
+        "c.Proxy.tcp_address = '127.0.0.1:8867'\n"
         "c.Proxy.log_level = 'debug'\n"
         "c.Proxy.api_token = 'abcde'"
     )
@@ -71,7 +71,7 @@ def test_proxy_cli(tmpdir, monkeypatch):
         "dask-gateway-proxy",
         "-address",
         "127.0.0.1:8866",
-        "-tls-address",
+        "-tcp-address",
         "127.0.0.1:8867",
         "-api-url",
         "http://127.0.0.1:8888/api/routes",

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -133,9 +133,8 @@ def test_client_init():
     config["gateway"]["proxy-address"] = None
 
     with dask.config.set(config):
-        # No proxy-address provided
-        with pytest.raises(ValueError):
-            Gateway()
+        g = Gateway()
+        assert g.proxy_address == "gateway://127.0.0.1:8888"
 
 
 def test_gateway_addresses_template_environment_vars(monkeypatch):

--- a/tests/test_db_backend.py
+++ b/tests/test_db_backend.py
@@ -748,7 +748,6 @@ async def test_gateway_resume_clusters_after_shutdown(tmpdir):
     config.LocalTestingBackend.check_timeouts_period = 0.5
     config.DaskGateway.address = "127.0.0.1:%d" % random_port()
     config.Proxy.address = "127.0.0.1:%d" % random_port()
-    config.Proxy.scheduler_address = "127.0.0.1:%d" % random_port()
 
     async with temp_gateway(config=config) as g:
         async with g.gateway_client() as gateway:

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -46,7 +46,6 @@ class temp_gateway(object):
 
         c.DaskGateway.address = "127.0.0.1:0"
         c.Proxy.address = "127.0.0.1:0"
-        c.Proxy.scheduler_address = "127.0.0.1:0"
         c.DaskGateway.authenticator_class = (
             "dask_gateway_server.auth.SimpleAuthenticator"
         )
@@ -63,7 +62,7 @@ class temp_gateway(object):
         await self.gateway.setup()
         await self.gateway.backend.proxy._proxy_contacted
         self.address = f"http://{self.gateway.backend.proxy.address}"
-        self.proxy_address = f"tls://{self.gateway.backend.proxy.scheduler_address}"
+        self.proxy_address = f"gateway://{self.gateway.backend.proxy.tcp_address}"
         return self
 
     async def __aexit__(self, *args):


### PR DESCRIPTION
Adds support for running both the TCP and HTTP proxies on the same port.

This relies on the SNI only being used for requests made by dask itself.
If the dask-gateway-server is running behind another proxy that makes
use of SNIs, then this method won't work and the proxies will have to
use separate ports (which is still supported).

Running all on the same point is nice from an administrative end (only
need to expose one port, not two), as well as a configuration end (users
only need to remember the main address, not the proxy address).