### PR TITLE
Update cluster_options docs for rearchitecture

### DIFF
--- a/dask-gateway-server/dask_gateway_server/options.py
+++ b/dask-gateway-server/dask_gateway_server/options.py
@@ -25,11 +25,11 @@ class Options(object):
     -------
 
     Here we expose options for users to configure
-    :data:`c.ClusterManager.worker_cores` and
-    :data:`c.ClusterManager.worker_memory`. We set bounds on each resource to
+    :data:`c.Backend.worker_cores` and
+    :data:`c.Backend.worker_memory`. We set bounds on each resource to
     prevent users from requesting too large of a worker. The handler is used to
     convert the user specified memory from GiB to bytes (as expected by
-    :data:`c.ClusterManager.worker_memory`).
+    :data:`c.Backend.worker_memory`).
 
     .. code-block:: python
 
@@ -41,7 +41,7 @@ class Options(object):
               "worker_memory": int(options.worker_memory * 2 ** 30)
           }
 
-      c.DaskGateway.cluster_manager_options = Options(
+      c.Backend.DaskGateway.cluster_options = Options(
           Integer("worker_cores", default=1, min=1, max=4, label="Worker Cores"),
           Float("worker_memory", default=1, min=1, max=8, label="Worker Memory (GiB)"),
           handler=options_handler,

--- a/docs/source/api-server.rst
+++ b/docs/source/api-server.rst
@@ -109,12 +109,6 @@ Proxy
 .. autoconfigurable:: dask_gateway_server.proxy.Proxy
 
 
-User Limits
------------
-
-.. autoconfigurable:: dask_gateway_server.limits.UserLimits
-
-
 Cluster Manager Options
 -----------------------
 

--- a/docs/source/api-server.rst
+++ b/docs/source/api-server.rst
@@ -26,40 +26,40 @@ JupyterHubAuthenticator
 .. autoconfigurable:: dask_gateway_server.auth.JupyterHubAuthenticator
 
 
-.. _dummy-auth-config:
+.. _simple-auth-config:
 
-DummyAuthenticator
-^^^^^^^^^^^^^^^^^^
+SimpleAuthenticator
+^^^^^^^^^^^^^^^^^^^
 
-.. autoconfigurable:: dask_gateway_server.auth.DummyAuthenticator
+.. autoconfigurable:: dask_gateway_server.auth.SimpleAuthenticator
 
 
-.. _cluster-managers-reference:
+.. _cluster-backends-reference:
 
-Cluster Managers
+Cluster Backends
 ----------------
 
 Base Class
 ^^^^^^^^^^
 
-ClusterManager
-~~~~~~~~~~~~~~
+Backend
+~~~~~~~
 
-.. autoconfigurable:: dask_gateway_server.managers.base.ClusterManager
+.. autoconfigurable:: dask_gateway_server.backends.Backend
 
 
 Local Processes
 ^^^^^^^^^^^^^^^
 
-LocalClusterManager
-~~~~~~~~~~~~~~~~~~~
+LocalBackend
+~~~~~~~~~~~~
 
-.. autoconfigurable:: dask_gateway_server.managers.local.LocalClusterManager
+.. autoconfigurable:: dask_gateway_server.backends.local.LocalBackend
 
-UnsafeLocalClusterManager
-~~~~~~~~~~~~~~~~~~~~~~~~~
+UnsafeLocalBackend
+~~~~~~~~~~~~~~~~~~
 
-.. autoconfigurable:: dask_gateway_server.managers.local.UnsafeLocalClusterManager
+.. autoconfigurable:: dask_gateway_server.backends.local.UnsafeLocalBackend
 
 
 YARN
@@ -67,21 +67,21 @@ YARN
 
 .. _yarn-config:
 
-YarnClusterManager
-~~~~~~~~~~~~~~~~~~
+YarnBackend
+~~~~~~~~~~~
 
-.. autoconfigurable:: dask_gateway_server.managers.yarn.YarnClusterManager
+.. autoconfigurable:: dask_gateway_server.backends.yarn.YarnBackend
 
 
 Kubernetes
 ^^^^^^^^^^
 
-.. _kube-cluster-manager-config:
+.. _kube-backend-config:
 
-KubeClusterManager
-~~~~~~~~~~~~~~~~~~
+KubeBackend
+~~~~~~~~~~~
 
-.. autoconfigurable:: dask_gateway_server.managers.kubernetes.KubeClusterManager
+.. autoconfigurable:: dask_gateway_server.backends.kubernetes.KubeBackend
 
 
 .. _jobqueue-config:
@@ -89,29 +89,24 @@ KubeClusterManager
 Job Queues
 ^^^^^^^^^^
 
-PBSClusterManager
-~~~~~~~~~~~~~~~~~
+PBSBackend
+~~~~~~~~~~
 
-.. autoconfigurable:: dask_gateway_server.managers.jobqueue.pbs.PBSClusterManager
+.. autoconfigurable:: dask_gateway_server.backends.jobqueue.pbs.PBSBackend
 
-SlurmClusterManager
-~~~~~~~~~~~~~~~~~~~
+SlurmBackend
+~~~~~~~~~~~~
 
-.. autoconfigurable:: dask_gateway_server.managers.jobqueue.slurm.SlurmClusterManager
+.. autoconfigurable:: dask_gateway_server.backends.jobqueue.slurm.SlurmBackend
 
 
-Proxies
--------
+Proxy
+-----
 
-Web Proxy
-^^^^^^^^^
+Proxy
+^^^^^
 
-.. autoconfigurable:: dask_gateway_server.proxy.WebProxy
-
-Scheduler Proxy
-^^^^^^^^^^^^^^^
-
-.. autoconfigurable:: dask_gateway_server.proxy.SchedulerProxy
+.. autoconfigurable:: dask_gateway_server.proxy.Proxy
 
 
 User Limits

--- a/docs/source/authentication.rst
+++ b/docs/source/authentication.rst
@@ -10,24 +10,24 @@ document a few common implementations.
 Simple authentication for testing
 ---------------------------------
 
-For testing purposes, a simple "dummy" authentication method can be used. This
-method implements Basic_ authentication, with no validation of the password
+For testing purposes, a "simple" authentication method can be used. This
+method implements authentication with no validation of the password
 field. As such, *it is not suitable for production, only for testing*. If
 desired, an optional password can be configured to be shared across all users.
 Note that this only marginally makes things more secure, as users can still
 easily impersonate each other.
 
 This protocol is the default, and is implemented by
-:class:`dask_gateway_server.auth.DummyAuthenticator`. No further configuration
+:class:`dask_gateway_server.auth.SimpleAuthenticator`. No further configuration
 is needed to enable it. If you would like to add a shared password, you can do
 so by adding the following line to your ``dask_gateway_config.py`` file:
 
 .. code-block:: python
 
     # Set a shared password.
-    c.DummyAuthenticator.password = "mypassword"
+    c.SimpleAuthenticator.password = "mypassword"
 
-For more information see the :ref:`dummy-auth-config` docs.
+For more information see the :ref:`simple-auth-config` docs.
 
 
 Kerberos authentication

--- a/docs/source/cluster-options.rst
+++ b/docs/source/cluster-options.rst
@@ -47,10 +47,17 @@ Server Configuration
 --------------------
 
 Options are exposed to the user by setting
-:data:`c.DaskGateway.cluster_manager_options`. This configuration field takes
-a :class:`dask_gateway_server.options.Options` object, which describes what
-options are exposed to end users, and how the gateway server should interpret
-those options.
+:data:`c.Backend.cluster_options`. This configuration field takes
+either:
+
+- a :class:`dask_gateway_server.options.Options` object, which describes what
+  options are exposed to end users, and how the gateway server should interpret
+  those options. This covers static configuration options that do not need to
+  change depending on information about a particular user
+
+- a function which returns a :class:`dask_gateway_server.options.Options` object
+  when called. This covers more dynamic configuration options that depend on a
+  user's permissions or groups they are a member of.
 
 .. autosummary:: ~dask_gateway_server.options.Options
 
@@ -97,8 +104,24 @@ fields on :ref:`KubeClusterManager <kube-cluster-manager-config>`. See
 :ref:`cluster-managers-reference` for information on what configuration fields
 are available on your backend.
 
-Examples
---------
+Dynamic Server Configuration
+----------------------------
+
+Dynamic configuration is available by passing a callable function to
+:data:`c.Backend.cluster_options`. This function should return a
+:class:`dask_gateway_server.options.Options` object. A callable
+``cluster_options`` function can be optionally ``async`` and receives a
+:class:`dask_gateway_server.models.User` object, which can be used to
+dynamically generate :data:`Options` based on username, group membership, or
+whether or not the logged-in user is an administrator.
+
+.. autosummary::
+    ~dask_gateway_server.models.User
+
+
+
+Static Configuration Examples
+-----------------------------
 
 Worker Cores and Memory
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -120,7 +143,7 @@ convert the user specified memory from GiB to bytes (as expected by
             "worker_memory": int(options.worker_memory * 2 ** 30),
         }
 
-    c.DaskGateway.cluster_manager_options = Options(
+    c.Backend.cluster_options = Options(
         Integer("worker_cores", default=1, min=1, max=4, label="Worker Cores"),
         Float("worker_memory", default=1, min=1, max=8, label="Worker Memory (GiB)"),
         handler=options_handler,
@@ -149,7 +172,7 @@ from.
     # Expose `profile` as an option, valid values are 'small', 'medium', or
     # 'large'. A handler is used to convert the profile name to the
     # corresponding configuration overrides.
-    c.DaskGateway.cluster_manager_options = Options(
+    c.Backend.cluster_options = Options(
         Select(
             "profile",
             ["small", "medium", "large"],
@@ -158,6 +181,44 @@ from.
         )
         handler=lambda options: profiles[options.profile],
     )
+
+Dynamic Configuration Examples
+------------------------------
+
+Worker Cores and Memory by Group
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Similar to the last examples, here we expose options for users to configure
+:data:`c.ClusterManager.worker_cores` and
+:data:`c.ClusterManager.worker_memory`. However, we offer different options to
+users depending on whether or not the user is a member of the "Power Users"
+group. 
+
+.. code-block:: python
+
+    from dask_gateway_server.options import Options, Integer, Float
+
+    def options_handler(options):
+        return {
+            "worker_cores": options.worker_cores,
+            "worker_memory": int(options.worker_memory * 2 ** 30),
+        }
+
+    def generate_options(user):
+        if "Power Users" in user.groups:
+            options = Options(
+                Integer("worker_cores", default=1, min=1, max=4, label="Worker Cores"),
+                Float("worker_memory", default=1, min=1, max=8, label="Worker Memory (GiB)"),
+                handler=options_handler,
+                )
+        else:
+            options = Options(
+                Integer("worker_cores", default=1, min=1, max=8, label="Worker Cores"),
+                Float("worker_memory", default=1, min=1, max=16, label="Worker Memory (GiB)"),
+                handler=options_handler,
+                )
+
+    c.Backend.cluster_options = generate_options
 
 
 .. _ipywidgets: https://ipywidgets.readthedocs.io/en/latest/

--- a/docs/source/cluster-options.rst
+++ b/docs/source/cluster-options.rst
@@ -100,8 +100,8 @@ returns the provided options unchanged.
 
 Available options are cluster manager specific. For example, if running on
 Kubernetes, an options handler can return overrides for any configuration
-fields on :ref:`KubeClusterManager <kube-cluster-manager-config>`. See
-:ref:`cluster-managers-reference` for information on what configuration fields
+fields on :ref:`KubeBackend <kube-backend-config>`. See
+:ref:`cluster-backends-reference` for information on what configuration fields
 are available on your backend.
 
 Dynamic Server Configuration
@@ -127,11 +127,11 @@ Worker Cores and Memory
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 Here we expose options for users to configure
-:data:`c.ClusterManager.worker_cores` and
-:data:`c.ClusterManager.worker_memory`. We set bounds on each resource to
+:data:`c.Backend.worker_cores` and
+:data:`c.Backend.worker_memory`. We set bounds on each resource to
 prevent users from requesting too large of a worker. The handler is used to
 convert the user specified memory from GiB to bytes (as expected by
-:data:`c.ClusterManager.worker_memory`).
+:data:`c.Backend.worker_memory`).
 
 .. code-block:: python
 
@@ -189,8 +189,8 @@ Worker Cores and Memory by Group
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Similar to the last examples, here we expose options for users to configure
-:data:`c.ClusterManager.worker_cores` and
-:data:`c.ClusterManager.worker_memory`. However, we offer different options to
+:data:`c.Backend.worker_cores` and
+:data:`c.Backend.worker_memory`. However, we offer different options to
 users depending on whether or not the user is a member of the "Power Users"
 group. 
 

--- a/docs/source/develop.rst
+++ b/docs/source/develop.rst
@@ -149,10 +149,10 @@ the documentation build requirements.
 .. code-block:: shell
 
     # Install docs dependencies with conda
-    $ conda install -c conda-forge skein sphinx
+    $ conda install -c conda-forge skein sphinx dask-sphinx-theme
 
     # Or install with pip
-    $ pip install sphinx skein
+    $ pip install sphinx skein dask-sphinx-theme
 
 Then build the documentation with ``make``
 

--- a/docs/source/install-kube.rst
+++ b/docs/source/install-kube.rst
@@ -48,23 +48,7 @@ The Helm chart provides access to configure most aspects of the
 ``dask-gateway-server``. These are provided via a configuration YAML_ file (the
 name of this file doesn't matter, we'll use ``config.yaml``).
 
-At a minimum, you'll need to set a value for ``gateway.proxyToken``. This is a
-random hex string representing 32 bytes, used as a security token between the
-gateway and its proxies. You can generate this using ``openssl``:
-
-.. code-block:: shell
-
-    $ openssl rand -hex 32
-
-Write the following into a new file ``config.yaml``, replacing ``<RANDOM
-TOKEN>`` with the output of the previous command above.
-
-.. code-block:: yaml
-
-    gateway:
-      proxyToken: "<RANDOM TOKEN>"
-
-The Helm chart exposes many more configuration values, see the `default
+The Helm chart exposes many configuration values, see the `default
 values.yaml file`_ for more information.
 
 
@@ -77,7 +61,7 @@ To install the Dask-Gateway Helm chart, run the following command:
 
     RELEASE=dask-gateway
     NAMESPACE=dask-gateway
-    VERSION=0.6.1
+    VERSION=0.7.0
 
     helm upgrade --install \
         --namespace $NAMESPACE \
@@ -100,18 +84,28 @@ where:
 
 Running this command may take some time, as resources are created and images
 are downloaded. When everything is ready, running the following command will
-show the ``EXTERNAL-IP`` addresses for all ``LoadBalancer`` services (highlighted
+show the ``EXTERNAL-IP`` addresses for the ``LoadBalancer`` service (highlighted
 below).
 
 .. code-block:: shell
-    :emphasize-lines: 4,6
+    :emphasize-lines: 3
 
     $ kubectl get service --namespace dask-gateway
-    NAME                            TYPE           CLUSTER-IP      EXTERNAL-IP      PORT(S)          AGE
-    scheduler-api-dask-gateway      ClusterIP      10.51.245.233   <none>           8001/TCP         6m54s
-    scheduler-public-dask-gateway   LoadBalancer   10.51.253.105   35.202.68.87     8786:31172/TCP   6m54s
-    web-api-dask-gateway            ClusterIP      10.51.250.11    <none>           8001/TCP         6m54s
-    web-public-dask-gateway         LoadBalancer   10.51.247.160   146.148.58.187   80:30304/TCP     6m54s
+    NAME                              TYPE           CLUSTER-IP      EXTERNAL-IP      PORT(S)          AGE
+    api-<RELEASE>-dask-gateway        ClusterIP      10.51.245.233   <none>           8000/TCP         6m54s
+    traefik-<RELEASE>-dask-gateway    LoadBalancer   10.51.247.160   146.148.58.187   80:30304/TCP     6m54s
+
+You can also check to make sure the `daskcluster` CRD has been installed successfully:
+
+.. code-block:: shell
+
+   $ kubectl get daskcluster -o yaml
+   apiVersion: v1
+   items: []
+   kind: List
+   metadata:
+     resourceVersion: ""
+     selfLink: ""
 
 At this point, you have a fully running ``dask-gateway-server``.
 
@@ -119,22 +113,21 @@ At this point, you have a fully running ``dask-gateway-server``.
 Connecting to the gateway
 -------------------------
 
-To connect to the running ``dask-gateway-server``, you'll need the external
-IPs from both the ``web-public-*`` and ``scheduler-public-*`` services above.
-The ``web-public-*`` service provides access to API requests, and also proxies
-out the `Dask Dashboards`_. The ``scheduler-public-*`` service proxies TCP
-traffic between Dask clients and schedulers.
+To connect to the running ``dask-gateway-server``, you'll need the external IPs
+from the ``traefik-*`` services above. The Traefik service provides access to
+API requests, proxies out the `Dask Dashboards`_, and proxies TCP traffic
+between Dask clients and schedulers. (You can also choose to have Traefik handle
+scheduler traffic over a separate port, see the :ref:`helm-chart-reference`).
 
 To connect, create a :class:`dask_gateway.Gateway` object, specifying the both
-addresses (the ``scheduler-proxy-*`` IP/port goes under ``proxy_address``).
-Using the same values as above:
+addresses (the second ``traefik-*`` port goes under ``proxy_address`` if using
+separate ports). Using the same values as above:
 
 .. code-block:: python
 
     >>> from dask_gateway import Gateway
     >>> gateway = Gateway(
     ...     "http://146.148.58.187",
-    ...     proxy_address="tls://35.202.68.87:8786"
     ... )
 
 You should now be able to use the gateway client to make API calls. To verify
@@ -173,10 +166,10 @@ to set on scheduler/worker pods are directly exposed by the Helm chart. To
 address this, we provide a few fields for forwarding configuration directly to
 the underlying kubernetes objects:
 
-- ``gateway.clusterManager.scheduler.extraPodConfig``
-- ``gateway.clusterManager.scheduler.extraContainerConfig``
-- ``gateway.clusterManager.worker.extraPodConfig``
-- ``gateway.clusterManager.worker.extraContainerConfig``
+- ``gateway.backend.scheduler.extraPodConfig``
+- ``gateway.backend.scheduler.extraContainerConfig``
+- ``gateway.backend.worker.extraPodConfig``
+- ``gateway.backend.worker.extraContainerConfig``
 
 These allow configuring any unexposed fields on the pod/container for
 schedulers and workers respectively. Each takes a mapping of key-value pairs,
@@ -192,7 +185,7 @@ anti-affinity for scheduler pods to avoid `preemptible nodes`_:
 .. code-block:: yaml
 
   gateway:
-    clusterManager:
+    backend:
       scheduler:
         extraPodConfig:
           affinity:
@@ -224,7 +217,7 @@ either:
   natively merge maps.
 
 For example, here we use ``gateway.extraConfig`` to set
-:data:`c.DaskGateway.cluster_manager_options`, exposing options for worker
+:data:`c.Backend.cluster_options`, exposing options for worker
 resources and image (see :doc:`cluster-options` for more information).
 
 .. code-block:: yaml
@@ -240,7 +233,7 @@ resources and image (see :doc:`cluster-options` for more information).
                 "image": options.image,
             }
 
-        c.DaskGateway.cluster_manager_options = Options(
+        c.Backend.cluster_options = Options(
             Integer("worker_cores", 2, min=1, max=4, label="Worker Cores"),
             Float("worker_memory", 4, min=1, max=8, label="Worker Memory (GiB)"),
             String("image", default="daskgateway/dask-gateway:latest", label="Image"),
@@ -318,7 +311,6 @@ object.
     >>> from dask_gateway import Gateway
     >>> gateway = Gateway(
     ...     "http://146.148.58.187",
-    ...     proxy_address="tls://35.202.68.87:8786",
     ...     auth="jupyterhub",
     ... )
 

--- a/docs/source/install-kube.rst
+++ b/docs/source/install-kube.rst
@@ -88,7 +88,7 @@ show the ``EXTERNAL-IP`` addresses for the ``LoadBalancer`` service (highlighted
 below).
 
 .. code-block:: shell
-    :emphasize-lines: 3
+    :emphasize-lines: 4
 
     $ kubectl get service --namespace dask-gateway
     NAME                              TYPE           CLUSTER-IP      EXTERNAL-IP      PORT(S)          AGE
@@ -241,7 +241,7 @@ resources and image (see :doc:`cluster-options` for more information).
         )
 
 For information on all available configuration options, see the
-:doc:`api-server` (in particular, the :ref:`kube-cluster-manager-config`
+:doc:`api-server` (in particular, the :ref:`kube-backend-config`
 section).
 
 


### PR DESCRIPTION
I didn't touch `install_kube.rst` yet since I imagine there will be more changes to come, but I think this is most of the docs that refer to `cluster_options` updated to reflect the new backend pattern and dynamic configuration options.

This can also be targeted at current `master` -- @jcrist let me know where you'd like it and I can move things around.