### PR TITLE
Use WorkQueue everywhere

### DIFF
--- a/dask-gateway-server/dask_gateway_server/utils.py
+++ b/dask-gateway-server/dask_gateway_server/utils.py
@@ -267,24 +267,6 @@ class LRUCache(object):
             pass
 
 
-class UniqueQueue(asyncio.Queue):
-    """A queue that may only contain each item once."""
-
-    def __init__(self, maxsize=0, *, loop=None):
-        super().__init__(maxsize=maxsize, loop=loop)
-        self._items = set()
-
-    def _put(self, item):
-        if item not in self._items:
-            self._items.add(item)
-            super()._put(item)
-
-    def _get(self):
-        item = super()._get()
-        self._items.discard(item)
-        return item
-
-
 class Flag(object):
     """A simpler version of asyncio.Event"""
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -304,7 +304,7 @@ async def test_create_cluster_with_GatewayCluster_constructor():
 
             await cluster.scale(1)
 
-            with cluster.get_client(set_as_default=False) as client:
+            async with cluster.get_client(set_as_default=False) as client:
                 res = await client.submit(lambda x: x + 1, 1)
                 assert res == 2
 

--- a/tests/test_db_backend.py
+++ b/tests/test_db_backend.py
@@ -615,7 +615,7 @@ async def test_successful_cluster():
             # Scale up, connect, and compute
             await cluster.scale(2)
 
-            with cluster.get_client(set_as_default=False) as client:
+            async with cluster.get_client(set_as_default=False) as client:
                 res = await client.submit(lambda x: x + 1, 1)
                 assert res == 2
 
@@ -623,7 +623,7 @@ async def test_successful_cluster():
             await cluster.scale(1)
 
             # Can still compute
-            with cluster.get_client(set_as_default=False) as client:
+            async with cluster.get_client(set_as_default=False) as client:
                 res = await client.submit(lambda x: x + 1, 1)
                 assert res == 2
 
@@ -801,7 +801,7 @@ async def test_gateway_resume_clusters_after_shutdown(tmpdir):
             async with gateway.connect(
                 cluster1_name, shutdown_on_close=True
             ) as cluster:
-                with cluster.get_client(set_as_default=False) as client:
+                async with cluster.get_client(set_as_default=False) as client:
                     res = await client.submit(lambda x: x + 1, 1)
                     assert res == 2
 
@@ -833,7 +833,7 @@ async def test_adaptive_scaling():
                 await cluster.adapt()
 
                 # Worker is automatically requested
-                with cluster.get_client(set_as_default=False) as client:
+                async with cluster.get_client(set_as_default=False) as client:
                     res = await client.submit(lambda x: x + 1, 1)
                     assert res == 2
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,7 +12,6 @@ from dask_gateway_server.utils import (
     cancel_task,
     TaskPool,
     LRUCache,
-    UniqueQueue,
     Flag,
     FrozenAttrDict,
     CancelGroup,
@@ -118,20 +117,6 @@ def test_lru_cache():
     cache.put(7, 8)
     assert cache.get(3) == 4
     assert cache.get(7) == 8
-
-
-@pytest.mark.asyncio
-async def test_unique_queue():
-    queue = UniqueQueue()
-
-    for data in [1, 3, 1, 2, 1, 2, 1, 3]:
-        await queue.put(data)
-
-    out = []
-    while not queue.empty():
-        out.append(await queue.get())
-
-    assert out == [1, 3, 2]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Previously we used `UniqueQueue` for managing reconcilation queues. When
writing the Kubernetes backend, I added a more featureful task queue in
``dask_gateway_server.workqueue.WorkQueue``. This supports concurrent
workers without hashing (any worker is free to work on any task, and no
task will be worked on twice concurrently), retries with backoffs, and
cleaner shutdowns.

Here we drop the ``UniqueQueue`` abstraction entirely, and use the
`WorkQueue` instead.

Also cleans up the test suite a bit to silence some warnings.