### PR TITLE
Run traefik as non-root user

### DIFF
--- a/resources/helm/dask-gateway/templates/traefik/deployment.yaml
+++ b/resources/helm/dask-gateway/templates/traefik/deployment.yaml
@@ -27,6 +27,9 @@ spec:
       containers:
         - name: traefik
           image: {{ .Values.traefik.image.name }}:{{ .Values.traefik.image.tag }}
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
           resources:
             {{- .Values.traefik.resources | toYaml | trimSuffix "\n" | nindent 12 }}
           args:


### PR DESCRIPTION
The traefik image defaults to running as root. This can cause issues if
a `PodSecurityPolicy` is enabled. To avoid this, we explicitly set a
`securityContext` on the traefik container, running as user `1000:1000`.

Fixes #224.