### PR TITLE
Fix for dashboard proxying with multi-namespace deployment

### DIFF
--- a/resources/helm/dask-gateway/templates/controller/configmap.yaml
+++ b/resources/helm/dask-gateway/templates/controller/configmap.yaml
@@ -13,7 +13,8 @@ data:
     c.KubeController.gateway_instance = '{{ include "dask-gateway.fullname" . }}'
     c.KubeController.proxy_prefix = "{{ .Values.gateway.prefix }}"
     c.KubeController.proxy_web_middlewares = [
-      {"name": '{{ include "dask-gateway.fullname" . | printf "clusters-prefix-%s" | trunc 63 | trimSuffix "-" }}'}
+      {"name": '{{ include "dask-gateway.fullname" . | printf "clusters-prefix-%s" | trunc 63 | trimSuffix "-" }}',
+      "namespace": '{{ .Release.Namespace }}'}
     ]
     c.KubeController.log_level = "{{ .Values.controller.loglevel }}"
     c.KubeController.completed_cluster_max_age = {{ .Values.controller.completedClusterMaxAge }}


### PR DESCRIPTION
Setting `gateway.backend.namespace` to a non-null value makes clusters deploy in
that namespace, but breaks the traefik proxying of the dashboards.  Deploying
the middleware to the backend namespace makes everything happy again.