### PR TITLE
Add /api/version route

### DIFF
--- a/continuous_integration/docker/hadoop/_install.sh
+++ b/continuous_integration/docker/hadoop/_install.sh
@@ -16,7 +16,7 @@ pip install \
     traitlets \
     sqlalchemy \
     skein \
-    pytest \
+    "pytest<5.4.0" \
     pytest-asyncio
 
 pushd dask-gateway

--- a/continuous_integration/docker/pbs/_install.sh
+++ b/continuous_integration/docker/pbs/_install.sh
@@ -15,7 +15,7 @@ pip install \
     cryptography \
     traitlets \
     sqlalchemy \
-    pytest \
+    "pytest<5.4.0" \
     pytest-asyncio
 
 pushd dask-gateway

--- a/continuous_integration/docker/slurm/_install.sh
+++ b/continuous_integration/docker/slurm/_install.sh
@@ -15,7 +15,7 @@ pip install \
     cryptography \
     traitlets \
     sqlalchemy \
-    pytest \
+    "pytest<5.4.0" \
     pytest-asyncio
 
 pushd dask-gateway

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -13,7 +13,7 @@ pip install \
     ipywidgets \
     jupyterhub \
     notebook \
-    pytest \
+    "pytest<5.4.0" \
     pytest-asyncio \
     sqlalchemy \
     tornado \

--- a/continuous_integration/kubernetes/install.sh
+++ b/continuous_integration/kubernetes/install.sh
@@ -9,7 +9,7 @@ pip install \
     dask \
     distributed \
     flake8 \
-    pytest \
+    "pytest<5.4.0" \
     pytest-asyncio \
     kubernetes-asyncio \
     sqlalchemy \

--- a/dask-gateway-server/dask_gateway_server/app.py
+++ b/dask-gateway-server/dask_gateway_server/app.py
@@ -261,5 +261,11 @@ class DaskGateway(Application):
         # TODO: add runtime checks here
         return {"status": "pass"}
 
+    def version_info(self):
+        """Handles the /api/version route"""
+        return {
+            "version": VERSION,
+        }
+
 
 main = DaskGateway.launch_instance

--- a/dask-gateway-server/dask_gateway_server/routes.py
+++ b/dask-gateway-server/dask_gateway_server/routes.py
@@ -78,6 +78,13 @@ async def health(request):
     return web.json_response(health, status=status)
 
 
+@default_routes.get("/api/version")
+@api_handler
+async def version(request):
+    version = request.app["gateway"].version_info()
+    return web.json_response(version, status=200)
+
+
 @default_routes.get("/api/v1/options")
 @api_handler(user_authenticated=True)
 async def cluster_options(request):

--- a/dask-gateway/dask_gateway/client.py
+++ b/dask-gateway/dask_gateway/client.py
@@ -446,6 +446,26 @@ class Gateway(object):
         """
         return self.sync(self._cluster_report, cluster_name, **kwargs)
 
+    async def _get_versions(self):
+        url = "%s/api/version" % self.address
+        resp = await self._request("GET", url)
+        server_info = await resp.json()
+        from . import __version__
+
+        return {
+            "server": server_info,
+            "client": {"version": __version__},
+        }
+
+    def get_versions(self):
+        """Return version info for the server and client
+
+        Returns
+        -------
+        version_info : dict
+        """
+        return self.sync(self._get_versions)
+
     def _config_cluster_options(self):
         opts = dask.config.get("gateway.cluster.options")
         return {k: format_template(v) for k, v in opts.items()}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -219,6 +219,18 @@ def test_http_client_proxy_explicit(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_get_versions():
+    from dask_gateway_server import __version__ as server_version
+    from dask_gateway import __version__ as client_version
+
+    async with temp_gateway() as g:
+        async with g.gateway_client() as gateway:
+            versions = await gateway.get_versions()
+            assert versions["client"]["version"] == client_version
+            assert versions["server"]["version"] == server_version
+
+
+@pytest.mark.asyncio
 async def test_client_reprs():
     async with temp_gateway() as g:
         async with g.gateway_client() as gateway:


### PR DESCRIPTION
Adds a route for getting the server version.

Currently this route is unauthenticated, taking JupyterHub's lead: https://jupyterhub.readthedocs.io/en/stable/_static/rest-api/index.html#path--. Besides K8s and JupyterHub, I couldn't find any other examples of version info routes.

Also adds `Gateway.get_versions` which returns both server and client version information.

Fixes #232.