### PR TITLE
Add user-level configurable annotations and labels

### DIFF
--- a/dask-gateway-server/dask_gateway_server/backends/kubernetes/backend.py
+++ b/dask-gateway-server/dask_gateway_server/backends/kubernetes/backend.py
@@ -234,7 +234,6 @@ class KubeClusterConfig(ClusterConfig):
 
         This dict will be merged with ``common_annotations`` before being
         applied to user pods.
-
         """,
         config=True,
     )
@@ -250,7 +249,6 @@ class KubeClusterConfig(ClusterConfig):
 
         This dict will be merged with ``common_annotations`` before being
         applied to user pods.
-
         """,
         config=True,
     )

--- a/dask-gateway-server/dask_gateway_server/backends/kubernetes/backend.py
+++ b/dask-gateway-server/dask_gateway_server/backends/kubernetes/backend.py
@@ -254,6 +254,7 @@ class KubeClusterConfig(ClusterConfig):
         config=True,
     )
 
+
 class KubeBackendAndControllerMixin(LoggingConfigurable):
     """Shared config between the backend and controller"""
 

--- a/dask-gateway-server/dask_gateway_server/backends/kubernetes/backend.py
+++ b/dask-gateway-server/dask_gateway_server/backends/kubernetes/backend.py
@@ -223,10 +223,9 @@ class KubeClusterConfig(ClusterConfig):
         config=True,
     )
 
-    extra_annotations = Dict(
+    worker_extra_pod_annotations = Dict(
         help="""
-        Any extra annotations to be applied to a user's scheduler and worker
-        pods.
+        Any extra annotations to be applied to a user's worker pods.
 
         These annotations can be set using with cluster options (See
         :ref:`exposing-cluster-options`) to allow for injecting user-specific
@@ -240,9 +239,39 @@ class KubeClusterConfig(ClusterConfig):
         config=True,
     )
 
-    extra_labels = Dict(
+    scheduler_extra_pod_annotations = Dict(
         help="""
-        Any extra labels to be applied to a user's scheduler and worker pods.
+        Any extra annotations to be applied to a user's scheduler pods.
+
+        These annotations can be set using with cluster options (See
+        :ref:`exposing-cluster-options`) to allow for injecting user-specific
+        information, e.g. adding an annotation based on a user's group or
+        username.
+
+        This dict will be merged with ``common_annotations`` before being
+        applied to user pods.
+
+        """,
+        config=True,
+    )
+
+    worker_extra_pod_labels = Dict(
+        help="""
+        Any extra labels to be applied to a user's worker pods.
+
+        These labels can be set using with cluster options (See
+        :ref:`exposing-cluster-options`) to allow for injecting user-specific
+        information, e.g. adding a label based on a user's group or username.
+
+        This dict will be merged with ``common_labels`` before being
+        applied to user pods.
+        """,
+        config=True,
+    )
+
+    scheduler_extra_pod_labels = Dict(
+        help="""
+        Any extra labels to be applied to a user's scheduler pods.
 
         These labels can be set using with cluster options (See
         :ref:`exposing-cluster-options`) to allow for injecting user-specific

--- a/dask-gateway-server/dask_gateway_server/backends/kubernetes/backend.py
+++ b/dask-gateway-server/dask_gateway_server/backends/kubernetes/backend.py
@@ -5,7 +5,7 @@ from base64 import b64decode
 from collections import defaultdict
 
 from traitlets import Float, Dict, Unicode, default
-from traitlets.config import Configurable
+from traitlets.config import LoggingConfigurable
 from kubernetes_asyncio import client, config
 from kubernetes_asyncio.client.rest import ApiException
 
@@ -223,8 +223,38 @@ class KubeClusterConfig(ClusterConfig):
         config=True,
     )
 
+    extra_annotations = Dict(
+        help="""
+        Any extra annotations to be applied to a user's scheduler and worker
+        pods.
 
-class KubeBackendAndControllerMixin(Configurable):
+        These annotations can be set using with cluster options (See
+        :ref:`exposing-cluster-options`) to allow for injecting user-specific
+        information, e.g. adding an annotation based on a user's group or
+        username.
+
+        This dict will be merged with ``common_annotations`` before being
+        applied to user pods.
+
+        """,
+        config=True,
+    )
+
+    extra_labels = Dict(
+        help="""
+        Any extra labels to be applied to a user's scheduler and worker pods.
+
+        These labels can be set using with cluster options (See
+        :ref:`exposing-cluster-options`) to allow for injecting user-specific
+        information, e.g. adding a label based on a user's group or username.
+
+        This dict will be merged with ``common_labels`` before being
+        applied to user pods.
+        """,
+        config=True,
+    )
+
+class KubeBackendAndControllerMixin(LoggingConfigurable):
     """Shared config between the backend and controller"""
 
     gateway_instance = Unicode(

--- a/dask-gateway-server/dask_gateway_server/backends/kubernetes/controller.py
+++ b/dask-gateway-server/dask_gateway_server/backends/kubernetes/controller.py
@@ -1117,8 +1117,6 @@ class KubeController(KubeBackendAndControllerMixin, Application):
                 }
             }
 
-        labels = self.get_labels(cluster_name, container_name)
-
         volume = {
             "name": "dask-credentials",
             "secret": {"secretName": f"dask-gateway-{cluster_name}"},
@@ -1153,12 +1151,11 @@ class KubeController(KubeBackendAndControllerMixin, Application):
         if extra_container_config:
             container = merge_json_objects(container, extra_container_config)
 
-        annotations = self.common_annotations
-        if extra_pod_annotations:
-            annotations = merge_json_objects(annotations, extra_pod_annotations)
+        annotations = self.common_annotations.copy()
+        annotations.update(extra_pod_annotations)
 
-        if extra_pod_labels:
-            labels.update(extra_pod_labels)
+        labels = self.get_labels(cluster_name, container_name)
+        labels.update(extra_pod_labels)
 
         pod = {
             "apiVersion": "v1",

--- a/dask-gateway-server/dask_gateway_server/backends/kubernetes/controller.py
+++ b/dask-gateway-server/dask_gateway_server/backends/kubernetes/controller.py
@@ -1093,6 +1093,8 @@ class KubeController(KubeBackendAndControllerMixin, Application):
             )
             extra_pod_config = config.worker_extra_pod_config
             extra_container_config = config.worker_extra_container_config
+            extra_pod_annotations = config.worker_extra_pod_annotations
+            extra_pod_labels = config.worker_extra_pod_labels
             probes = {}
         else:
             container_name = "dask-scheduler"
@@ -1103,6 +1105,8 @@ class KubeController(KubeBackendAndControllerMixin, Application):
             cmd = self.get_scheduler_command(namespace, cluster_name, config)
             extra_pod_config = config.scheduler_extra_pod_config
             extra_container_config = config.scheduler_extra_container_config
+            extra_pod_annotations = config.scheduler_extra_pod_annotations
+            extra_pod_labels = config.scheduler_extra_pod_labels
             # TODO: make this configurable. If supported, we should use a
             # startupProbe here instead.
             probes = {
@@ -1114,8 +1118,6 @@ class KubeController(KubeBackendAndControllerMixin, Application):
             }
 
         labels = self.get_labels(cluster_name, container_name)
-        extra_annotations = config.extra_annotations
-        extra_labels = config.extra_labels
 
         volume = {
             "name": "dask-credentials",
@@ -1152,11 +1154,11 @@ class KubeController(KubeBackendAndControllerMixin, Application):
             container = merge_json_objects(container, extra_container_config)
 
         annotations = self.common_annotations
-        if extra_annotations:
-            annotations = merge_json_objects(annotations, extra_annotations)
+        if extra_pod_annotations:
+            annotations = merge_json_objects(annotations, extra_pod_annotations)
 
-        if extra_labels:
-            labels.update(extra_labels)
+        if extra_pod_labels:
+            labels.update(extra_pod_labels)
 
         pod = {
             "apiVersion": "v1",

--- a/dask-gateway-server/dask_gateway_server/backends/kubernetes/controller.py
+++ b/dask-gateway-server/dask_gateway_server/backends/kubernetes/controller.py
@@ -1114,6 +1114,8 @@ class KubeController(KubeBackendAndControllerMixin, Application):
             }
 
         labels = self.get_labels(cluster_name, container_name)
+        extra_annotations = config.extra_annotations
+        extra_labels = config.extra_labels
 
         volume = {
             "name": "dask-credentials",
@@ -1149,10 +1151,17 @@ class KubeController(KubeBackendAndControllerMixin, Application):
         if extra_container_config:
             container = merge_json_objects(container, extra_container_config)
 
+        annotations = self.common_annotations
+        if extra_annotations:
+            annotations = merge_json_objects(annotations, extra_annotations)
+
+        if extra_labels:
+            labels.update(extra_labels)
+
         pod = {
             "apiVersion": "v1",
             "kind": "Pod",
-            "metadata": {"labels": labels, "annotations": self.common_annotations},
+            "metadata": {"labels": labels, "annotations": annotations},
             "spec": {
                 "containers": [container],
                 "volumes": [volume],

--- a/docs/source/cluster-options.rst
+++ b/docs/source/cluster-options.rst
@@ -1,3 +1,5 @@
+.. _exposing-cluster-options:
+
 Exposing Cluster Options
 ========================
 

--- a/tests/kubernetes/test_methods.py
+++ b/tests/kubernetes/test_methods.py
@@ -146,6 +146,8 @@ def example_config():
         "scheduler_memory_limit": "3G",
         "scheduler_cores": 1,
         "scheduler_cores_limit": 2,
+        "extra_labels": {"user-specific-label": "orkbork"},
+        "extra_annotations": {"user-specific-annotation": "Role1"}
     }
     return FrozenAttrDict(KubeClusterConfig(**kwargs).to_dict())
 
@@ -183,6 +185,10 @@ def test_make_pod(is_worker):
     assert labels["gateway.dask.org/instance"] == "instance-1234"
     assert labels["gateway.dask.org/cluster"] == cluster_name
     assert labels["app.kubernetes.io/component"] == component
+    assert labels["user-specific-label"] == "orkbork"
+
+    annotations = pod["metadata"]["annotations"]
+    assert annotations["user-specific-annotation"] == "Role1"
 
     assert pod["spec"]["tolerations"] == tolerations
     container = pod["spec"]["containers"][0]

--- a/tests/kubernetes/test_methods.py
+++ b/tests/kubernetes/test_methods.py
@@ -147,7 +147,7 @@ def example_config():
         "scheduler_cores": 1,
         "scheduler_cores_limit": 2,
         "extra_labels": {"user-specific-label": "orkbork"},
-        "extra_annotations": {"user-specific-annotation": "Role1"}
+        "extra_annotations": {"user-specific-annotation": "Role1"},
     }
     return FrozenAttrDict(KubeClusterConfig(**kwargs).to_dict())
 

--- a/tests/kubernetes/test_methods.py
+++ b/tests/kubernetes/test_methods.py
@@ -146,8 +146,12 @@ def example_config():
         "scheduler_memory_limit": "3G",
         "scheduler_cores": 1,
         "scheduler_cores_limit": 2,
-        "extra_labels": {"user-specific-label": "orkbork"},
-        "extra_annotations": {"user-specific-annotation": "Role1"},
+        "scheduler_extra_pod_labels": {"user-specific-label": "orkbork_scheduler"},
+        "worker_extra_pod_labels": {"user-specific-label": "orkbork_worker"},
+        "scheduler_extra_pod_annotations": {
+            "user-specific-annotation": "scheduler_role1"
+        },
+        "worker_extra_pod_annotations": {"user-specific-annotation": "worker_role1"},
     }
     return FrozenAttrDict(KubeClusterConfig(**kwargs).to_dict())
 
@@ -185,10 +189,15 @@ def test_make_pod(is_worker):
     assert labels["gateway.dask.org/instance"] == "instance-1234"
     assert labels["gateway.dask.org/cluster"] == cluster_name
     assert labels["app.kubernetes.io/component"] == component
-    assert labels["user-specific-label"] == "orkbork"
 
     annotations = pod["metadata"]["annotations"]
-    assert annotations["user-specific-annotation"] == "Role1"
+
+    if is_worker:
+        assert labels["user-specific-label"] == "orkbork_worker"
+        assert annotations["user-specific-annotation"] == "worker_role1"
+    else:
+        assert labels["user-specific-label"] == "orkbork_scheduler"
+        assert annotations["user-specific-annotation"] == "scheduler_role1"
 
     assert pod["spec"]["tolerations"] == tolerations
     container = pod["spec"]["containers"][0]


### PR DESCRIPTION
This adds two new configurable options for the `KubeClusterConfig`:
`extra_annotatations` and `extra_labels`. These can be configured using
`cluster_options` and get merged with `common_annotations` and
`common_labels`, respectively.

There are already config options for `common_labels` and
`common_annotations`, so why does this exist?  Those config options are
part of the `KubeBackend` and can be used by a cluster admin to add an
extra label (say) to every pod Dask Gateway spins up.

`extra_annotations` and `extra_labels` can be configured on a
user-by-user basis, to allow for attaching user-specific annotations to
help configure data access (as one example). These options can be
populated using external services based on information in the `User`
model (name, groups, admin).