### PR TITLE
Add liveness and readiness probes to API deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ htmlcov/
 .cache/
 .pytest_cache/
 .DS_Store
+.vscode

--- a/resources/helm/dask-gateway/templates/gateway/deployment.yaml
+++ b/resources/helm/dask-gateway/templates/gateway/deployment.yaml
@@ -57,19 +57,25 @@ spec:
           ports:
             - containerPort: 8000
               name: api
+
+          {{- if .Values.gateway.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /api/health
               port: api
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            timeoutSeconds: 2
-            failureThreshold: 3
+            initialDelaySeconds: {{ .Values.gateway.livenessProbe.initialDelaySecond }}
+            periodSeconds: {{ .Values.gateway.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.gateway.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.gateway.livenessProbe.failureThreshold }}
+          {{- end }}
+
+          {{- if .Values.gateway.livenessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /api/health
               port: api
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            timeoutSeconds: 2
-            failureThreshold: 1
+            initialDelaySeconds: {{ .Values.gateway.readinessProbe.initialDelaySecond }}
+            periodSeconds: {{ .Values.gateway.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.gateway.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.gateway.readinessProbe.failureThreshold }}
+          {{- end }}

--- a/resources/helm/dask-gateway/templates/gateway/deployment.yaml
+++ b/resources/helm/dask-gateway/templates/gateway/deployment.yaml
@@ -57,3 +57,19 @@ spec:
           ports:
             - containerPort: 8000
               name: api
+          livenessProbe:
+            httpGet:
+              path: /api/health
+              port: api
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /api/health
+              port: api
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 2
+            failureThreshold: 1

--- a/resources/helm/dask-gateway/templates/gateway/deployment.yaml
+++ b/resources/helm/dask-gateway/templates/gateway/deployment.yaml
@@ -63,7 +63,7 @@ spec:
             httpGet:
               path: /api/health
               port: api
-            initialDelaySeconds: {{ .Values.gateway.livenessProbe.initialDelaySecond }}
+            initialDelaySeconds: {{ .Values.gateway.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.gateway.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.gateway.livenessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.gateway.livenessProbe.failureThreshold }}
@@ -74,7 +74,7 @@ spec:
             httpGet:
               path: /api/health
               port: api
-            initialDelaySeconds: {{ .Values.gateway.readinessProbe.initialDelaySecond }}
+            initialDelaySeconds: {{ .Values.gateway.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.gateway.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.gateway.readinessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.gateway.readinessProbe.failureThreshold }}

--- a/resources/helm/dask-gateway/templates/gateway/deployment.yaml
+++ b/resources/helm/dask-gateway/templates/gateway/deployment.yaml
@@ -69,7 +69,7 @@ spec:
             failureThreshold: {{ .Values.gateway.livenessProbe.failureThreshold }}
           {{- end }}
 
-          {{- if .Values.gateway.livenessProbe.enabled }}
+          {{- if .Values.gateway.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /api/health

--- a/resources/helm/dask-gateway/values.yaml
+++ b/resources/helm/dask-gateway/values.yaml
@@ -54,6 +54,23 @@ gateway:
       # Configuration fields to set on the authenticator class.
       options: {}
 
+  livenessProbe:
+    # Enables the livenessProbe. 
+    enabled: true
+    # Configures the livenessProbe. 
+    initialDelaySeconds: 5
+    timeoutSeconds: 2
+    periodSeconds: 10
+    failureThreshold: 3
+  readinessProbe:
+    # Enables the readinessProbe.
+    enabled: true
+    # Configures the readinessProbe.
+    initialDelaySeconds: 5
+    timeoutSeconds: 2
+    periodSeconds: 10
+    failureThreshold: 1
+
   backend:
     # The image to use for both schedulers and workers.
     image:

--- a/resources/helm/dask-gateway/values.yaml
+++ b/resources/helm/dask-gateway/values.yaml
@@ -61,7 +61,7 @@ gateway:
     initialDelaySeconds: 5
     timeoutSeconds: 2
     periodSeconds: 10
-    failureThreshold: 3
+    failureThreshold: 6
   readinessProbe:
     # Enables the readinessProbe.
     enabled: true
@@ -69,7 +69,7 @@ gateway:
     initialDelaySeconds: 5
     timeoutSeconds: 2
     periodSeconds: 10
-    failureThreshold: 1
+    failureThreshold: 3
 
   backend:
     # The image to use for both schedulers and workers.


### PR DESCRIPTION
Idiomatically, production pods should leverage liveness probes. Liveness probes ensure that pods are restarted if the application is unresponsive but the main process is still running. 

> For pods running in production, you should always define a liveness probe. Without one, Kubernetes has no way of knowing whether your app is still alive or not. As long as the process is still running, Kubernetes will consider the container to be healthy.
-- From **Kubernetes in Action** by Marko Luksa

Dask Gateway Server includes a [health check endpoint](https://github.cloud.capitalone.com/dask/dask-gateway/blob/bfb771cec733571bf9090349316cfce6ca9d1b1d/dask-gateway-server/dask_gateway_server/routes.py#L70), but kubelet isn't checking it. 

This PR updates the Helm deployment for Dask Gateway Server to include [liveness and readiness probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/). 

I tested this on my local machine using Docker Desktop Kubernetes and confirmed that everything works. 

Major kudos to @suchitpandya for identifying this discrepancy. 