### PR TITLE
Fix dashboard_url for distributed.Client

### DIFF
--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -13,8 +13,8 @@ pip install \
     ipywidgets \
     jupyterhub \
     notebook \
-    "pytest>=5.4.0" \
-    pytest-asyncio \
+    pytest \
+    pytest-asyncio==0.10.0 \
     sqlalchemy \
     tornado \
     traitlets \

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -13,7 +13,7 @@ pip install \
     ipywidgets \
     jupyterhub \
     notebook \
-    pytest \
+    "pytest>=5.4.0" \
     pytest-asyncio \
     sqlalchemy \
     tornado \

--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -13,7 +13,7 @@ pip install \
     ipywidgets \
     jupyterhub \
     notebook \
-    "pytest<5.4.0" \
+    pytest \
     pytest-asyncio \
     sqlalchemy \
     tornado \

--- a/dask-gateway/dask_gateway/client.py
+++ b/dask-gateway/dask_gateway/client.py
@@ -1020,7 +1020,7 @@ class GatewayCluster(object):
         -------
         client : dask.distributed.Client
         """
-        client = GatewayClient(
+        client = GatewayClusterClient(
             self.scheduler_address,
             security=self.security,
             set_as_default=set_as_default,
@@ -1191,7 +1191,7 @@ class GatewayCluster(object):
         ).format(name=self.name, dashboard=dashboard)
 
 
-class GatewayClient(Client):
+class GatewayClusterClient(Client):
     """A subclass of distributed.Client used for Dask Gateway customizations
 
     This subclass is used by Dask Gateway in order to override the parent's (distributed.Client) "dashboard_link" property until a

--- a/dask-gateway/dask_gateway/client.py
+++ b/dask-gateway/dask_gateway/client.py
@@ -1020,13 +1020,14 @@ class GatewayCluster(object):
         -------
         client : dask.distributed.Client
         """
-        client = Client(
+        client = GatewayClient(
             self.scheduler_address,
             security=self.security,
             set_as_default=set_as_default,
             asynchronous=self.asynchronous,
             loop=self.loop,
         )
+        client._dashboard_link=self.dashboard_link
         if not self.asynchronous:
             self._clients.add(client)
         return client
@@ -1188,3 +1189,15 @@ class GatewayCluster(object):
             "  </ul>\n"
             "</div>\n"
         ).format(name=self.name, dashboard=dashboard)
+
+
+class GatewayClient(Client):
+    """A subclass of distributed.Client used for Dask Gateway customizations
+
+    This subclass is used by Dask Gateway in order to override the parent's (distributed.Client) "dashboard_link" property until a
+    version of distributed.Client allows us to override the value natively.
+
+    """
+    @property
+    def dashboard_link(self):
+        return self._dashboard_link

--- a/dask-gateway/dask_gateway/client.py
+++ b/dask-gateway/dask_gateway/client.py
@@ -1020,14 +1020,13 @@ class GatewayCluster(object):
         -------
         client : dask.distributed.Client
         """
-        client = GatewayClusterClient(
-            self.scheduler_address,
+        client = Client(
+            self,
             security=self.security,
             set_as_default=set_as_default,
             asynchronous=self.asynchronous,
             loop=self.loop,
         )
-        client._dashboard_link=self.dashboard_link
         if not self.asynchronous:
             self._clients.add(client)
         return client
@@ -1189,15 +1188,3 @@ class GatewayCluster(object):
             "  </ul>\n"
             "</div>\n"
         ).format(name=self.name, dashboard=dashboard)
-
-
-class GatewayClusterClient(Client):
-    """A subclass of distributed.Client used for Dask Gateway customizations
-
-    This subclass is used by Dask Gateway in order to override the parent's (distributed.Client) "dashboard_link" property until a
-    version of distributed.Client allows us to override the value natively.
-
-    """
-    @property
-    def dashboard_link(self):
-        return self._dashboard_link

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -244,6 +244,10 @@ async def test_client_reprs():
             assert cluster.name in cluster._repr_html_()
             assert cluster.dashboard_link in cluster._repr_html_()
 
+            # Client dashboard link
+            client = cluster.get_client()
+            assert client.dashboard_link == cluster.dashboard_link
+
             # HTML repr with no dashboard
             cluster.dashboard_link = None
             assert "Not Available" in cluster._repr_html_()


### PR DESCRIPTION
Fixed the dashboard URL for the client returned in GatewayCluster.get_client()

distributed.Client.dashboard_link (See https://github.com/dask/distributed/blob/master/distributed/client.py#L750-L764) is implemented in a way such that if the scheduler address has a non-root (i.e. /) path, and/or if the scheduler proxy does not use the same port as the internal scheduler port, the dashboard link will be generated incorrectly. The final dashboard link will have the path dropped, and the port will be set to use the internal port rather than the proxy port .The dashboard link's host is generated correctly.

Is the dashboard URL always going to be the scheduler URL + "/status"?
If that's the case, then the logic for getting distributed.Client.dashboard_link should be updated to reflect that relationship.
We will still need a way to deduce the protocol for the dashboard link.

An alternative fix to this would be to set the "cluster" attribute of a distributed.Client in GatewayCluster.get_client() (by setting it to "self").
This change could be a bit more complicated because the distributed.Client expects "cluster" to be LocalCluster-compatible.

Temporarily resolves #247