### PR TITLE
[WIP] Cluster resource limits

### DIFF
--- a/dask-gateway-server/dask_gateway_server/backends/db_base.py
+++ b/dask-gateway-server/dask_gateway_server/backends/db_base.py
@@ -207,6 +207,7 @@ class Cluster(object):
             username=self.username,
             token=self.token,
             options=self.options,
+            config=self.config,
             status=self.model_status,
             scheduler_address=self.scheduler_address,
             dashboard_address=self.dashboard_address,
@@ -955,6 +956,18 @@ class DBBackendBase(Backend):
             len(closing_workers),
             len(closed_workers),
         )
+
+        max_workers = cluster.config.get("cluster_max_workers")
+        if max_workers is not None and count > max_workers:
+            # This shouldn't happen under normal operation, but could if the
+            # user does something malicious (or there's a bug).
+            self.log.info(
+                "Cluster %s heartbeat requested %d workers, exceeding limit of %s.",
+                cluster_name,
+                count,
+                max_workers,
+            )
+            count = max_workers
 
         if count != cluster.count:
             cluster_update["count"] = count

--- a/dask-gateway-server/dask_gateway_server/models.py
+++ b/dask-gateway-server/dask_gateway_server/models.py
@@ -78,6 +78,8 @@ class Cluster(object):
         The normalized set of configuration options provided when starting this
         cluster. These values are user-facing, and don't necessarily correspond
         with the ``ClusterConfig`` options on the backend.
+    config : dict
+        The serialized version of ``ClusterConfig`` for this cluster.
     status : ClusterStatus
         The status of the cluster.
     scheduler_address : str
@@ -103,6 +105,7 @@ class Cluster(object):
         username,
         token,
         options,
+        config,
         status,
         scheduler_address="",
         dashboard_address="",
@@ -116,6 +119,7 @@ class Cluster(object):
         self.username = username
         self.token = token
         self.options = options
+        self.config = config
         self.status = status
         self.scheduler_address = scheduler_address
         self.dashboard_address = dashboard_address

--- a/dask-gateway-server/dask_gateway_server/routes.py
+++ b/dask-gateway-server/dask_gateway_server/routes.py
@@ -198,13 +198,23 @@ async def scale_cluster(request):
             reason=f"Scale expects a non-negative integer, got {count}"
         )
 
+    max_workers = cluster.config.get("cluster_max_workers")
+    resp_msg = None
+    if max_workers is not None and count > max_workers:
+        resp_msg = (
+            f"Scale request of {count} workers would exceed resource limit of "
+            f"{max_workers} workers. Scaling to {max_workers} instead."
+        )
+        count = max_workers
+
     try:
         await backend.forward_message_to_scheduler(
             cluster, {"op": "scale", "count": count}
         )
     except PublicException as exc:
         raise web.HTTPConflict(reason=str(exc))
-    return web.Response()
+
+    return web.json_response({"ok": not resp_msg, "msg": resp_msg})
 
 
 @default_routes.post("/api/v1/clusters/{cluster_name}/adapt")
@@ -226,6 +236,18 @@ async def adapt_cluster(request):
     maximum = msg.get("maximum", None)
     active = msg.get("active", True)
 
+    max_workers = cluster.config.get("cluster_max_workers")
+    resp_msg = None
+    if max_workers is not None:
+        if maximum is None:
+            maximum = max_workers
+        elif maximum > max_workers:
+            resp_msg = (
+                f"Adapt with `maximum={maximum}` workers would exceed resource limit of "
+                f"{max_workers} workers. Using `maximum={max_workers}` instead."
+            )
+            maximum = max_workers
+
     try:
         await backend.forward_message_to_scheduler(
             cluster,
@@ -233,7 +255,8 @@ async def adapt_cluster(request):
         )
     except PublicException as exc:
         raise web.HTTPConflict(reason=str(exc))
-    return web.Response()
+
+    return web.json_response({"ok": not resp_msg, "msg": resp_msg})
 
 
 @default_routes.post("/api/v1/clusters/{cluster_name}/heartbeat")
@@ -242,7 +265,10 @@ async def handle_heartbeat(request):
     backend = request.app["backend"]
     cluster_name = request.match_info["cluster_name"]
     msg = await request.json()
-    await backend.on_cluster_heartbeat(cluster_name, msg)
+    try:
+        await backend.on_cluster_heartbeat(cluster_name, msg)
+    except PublicException as exc:
+        raise web.HTTPConflict(reason=str(exc))
     return web.Response()
 
 

--- a/dask-gateway-server/dask_gateway_server/routes.py
+++ b/dask-gateway-server/dask_gateway_server/routes.py
@@ -241,12 +241,18 @@ async def adapt_cluster(request):
     if max_workers is not None:
         if maximum is None:
             maximum = max_workers
-        elif maximum > max_workers:
+        if minimum is None:
+            minimum = 0
+        if maximum > max_workers or minimum > max_workers:
+            orig_max = maximum
+            orig_min = minimum
+            maximum = min(max_workers, maximum)
+            minimum = min(max_workers, minimum)
             resp_msg = (
-                f"Adapt with `maximum={maximum}` workers would exceed resource limit of "
-                f"{max_workers} workers. Using `maximum={max_workers}` instead."
+                f"Adapt with `maximum={orig_max}, minimum={orig_min}` workers "
+                f"would exceed resource limit of {max_workers} workers. Using "
+                f"`maximum={maximum}, minimum={minimum}` instead."
             )
-            maximum = max_workers
 
     try:
         await backend.forward_message_to_scheduler(

--- a/dask-gateway/dask_gateway/client.py
+++ b/dask-gateway/dask_gateway/client.py
@@ -641,7 +641,13 @@ class Gateway(object):
 
     async def _scale_cluster(self, cluster_name, n):
         url = "%s/api/v1/clusters/%s/scale" % (self.address, cluster_name)
-        await self._request("POST", url, json={"count": n})
+        resp = await self._request("POST", url, json={"count": n})
+        try:
+            msg = await resp.json()
+        except Exception:
+            msg = {}
+        if not msg.get("ok", True) and msg.get("msg"):
+            warnings.warn(GatewayWarning(msg["msg"]))
 
     def scale_cluster(self, cluster_name, n, **kwargs):
         """Scale a cluster to n workers.
@@ -658,11 +664,17 @@ class Gateway(object):
     async def _adapt_cluster(
         self, cluster_name, minimum=None, maximum=None, active=True
     ):
-        await self._request(
+        resp = await self._request(
             "POST",
             "%s/api/v1/clusters/%s/adapt" % (self.address, cluster_name),
             json={"minimum": minimum, "maximum": maximum, "active": active},
         )
+        try:
+            msg = await resp.json()
+        except Exception:
+            msg = {}
+        if not msg.get("ok", True) and msg.get("msg"):
+            warnings.warn(GatewayWarning(msg["msg"]))
 
     def adapt_cluster(
         self, cluster_name, minimum=None, maximum=None, active=True, **kwargs

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -90,6 +90,7 @@ both the cluster backend and the authentication protocol are pluggable.
    authentication
    security
    cluster-options
+   resource-limits
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/resource-limits.rst
+++ b/docs/source/resource-limits.rst
@@ -1,0 +1,28 @@
+Cluster Resource Limits
+=======================
+
+By default users can create clusters with as many workers and resources as they
+want.  In shared environments this may not always be desirable. To remedy this
+administrators can set per-cluster resource limits.
+
+A few limits are available:
+
+- :data:`c.ClusterConfig.cluster_max_cores`: Maximum number of cores per cluster
+- :data:`c.ClusterConfig.cluster_max_memory`: Maximum amount of memory per cluster
+- :data:`c.ClusterConfig.cluster_max_workers`: Maximum number of workers per cluster
+
+If a cluster is at capacity for any of these limits, requests for new workers
+or workers will warn with an informative message saying they're at capacity.
+
+Example
+-------
+
+Here we limit each cluster to:
+
+- A max of 80 active cores
+- A max of 1 TiB of RAM
+
+.. code-block:: python
+
+    c.ClusterConfig.cluster_max_cores = 80
+    c.ClusterConfig.cluster_max_memory = "1 T"


### PR DESCRIPTION
This adds resource limits *per cluster*. Currently we support:

- Max cores per cluster
- Max memory per cluster
- Max workers per cluster

At runtime these are normalized into a single `cluster_max_workers`
field, which is used to check incoming scale and adapt requests. If a
request from a user exceeds the limit, it is trimmed to be within
bounds, and a warning is raised in the user's terminal notifying them of
the limit.

Still needs tests and docs.

Fixes #249.