### PR TITLE
Add --no-nanny arg to worker cli

### DIFF
--- a/dask-gateway-server/dask_gateway_server/backends/base.py
+++ b/dask-gateway-server/dask_gateway_server/backends/base.py
@@ -6,7 +6,7 @@ from traitlets.config import LoggingConfigurable, Configurable
 
 from .. import models
 from ..options import Options
-from ..traitlets import MemoryLimit, Type, Callable
+from ..traitlets import MemoryLimit, Type, Callable, Command
 from ..utils import awaitable
 
 
@@ -231,13 +231,13 @@ class Backend(LoggingConfigurable):
 class ClusterConfig(Configurable):
     """Base class for holding individual Dask cluster configurations"""
 
-    scheduler_cmd = Unicode(
+    scheduler_cmd = Command(
         "dask-gateway-scheduler",
         help="Shell command to start a dask-gateway scheduler.",
         config=True,
     )
 
-    worker_cmd = Unicode(
+    worker_cmd = Command(
         "dask-gateway-worker",
         help="Shell command to start a dask-gateway worker.",
         config=True,

--- a/dask-gateway-server/dask_gateway_server/backends/db_base.py
+++ b/dask-gateway-server/dask_gateway_server/backends/db_base.py
@@ -1382,8 +1382,7 @@ class DBBackendBase(Backend):
         return out
 
     def get_scheduler_command(self, cluster):
-        return [
-            cluster.config.scheduler_cmd,
+        return cluster.config.scheduler_cmd + [
             "--heartbeat-period",
             str(self.cluster_heartbeat_period),
             "--adaptive-period",
@@ -1393,7 +1392,7 @@ class DBBackendBase(Backend):
         ]
 
     def get_worker_command(self, cluster):
-        return [cluster.config.worker_cmd]
+        return cluster.config.worker_cmd
 
     # Subclasses should implement these methods
     supports_bulk_shutdown = False

--- a/dask-gateway-server/dask_gateway_server/backends/kubernetes/controller.py
+++ b/dask-gateway-server/dask_gateway_server/backends/kubernetes/controller.py
@@ -1022,8 +1022,7 @@ class KubeController(KubeBackendAndControllerMixin, Application):
         return route["metadata"]["name"]
 
     def get_scheduler_command(self, namespace, cluster_name, config):
-        return [
-            config.scheduler_cmd,
+        return config.scheduler_cmd + [
             "--scheduler-address",
             ":8786",
             "--dashboard-address",
@@ -1040,8 +1039,7 @@ class KubeController(KubeBackendAndControllerMixin, Application):
 
     def get_worker_command(self, namespace, cluster_name, config):
         service_name = self.make_service_name(cluster_name)
-        return [
-            config.worker_cmd,
+        return config.worker_cmd + [
             "--nthreads",
             str(int(config.worker_cores_limit)),
             "--memory-limit",

--- a/dask-gateway-server/dask_gateway_server/backends/yarn.py
+++ b/dask-gateway-server/dask_gateway_server/backends/yarn.py
@@ -131,8 +131,7 @@ class YarnBackend(DBBackendBase):
         return out
 
     def get_worker_command(self, cluster):
-        return [
-            cluster.config.worker_cmd,
+        return cluster.config.worker_cmd + [
             "--nthreads",
             "$SKEIN_RESOURCE_VCORES",
             "--memory-limit",

--- a/dask-gateway-server/dask_gateway_server/traitlets.py
+++ b/dask-gateway-server/dask_gateway_server/traitlets.py
@@ -1,4 +1,4 @@
-from traitlets import TraitError, TraitType, Integer, Type as _Type
+from traitlets import TraitError, TraitType, Integer, List, Unicode, Type as _Type
 from traitlets.config import Application
 
 
@@ -68,4 +68,21 @@ class Type(_Type):
                     "Failed to import %r for trait '%s.%s':\n\n%s"
                     % (value, type(obj).__name__, self.name, exc)
                 )
+        return super().validate(obj, value)
+
+
+class Command(List):
+    """Traitlet for a command that should be a list of strings,
+    but allows it to be specified as a single string.
+    """
+
+    def __init__(self, default_value=None, **kwargs):
+        kwargs.setdefault('minlen', 1)
+        if isinstance(default_value, str):
+            default_value = [default_value]
+        super().__init__(Unicode(), default_value, **kwargs)
+
+    def validate(self, obj, value):
+        if isinstance(value, str):
+            value = [value]
         return super().validate(obj, value)

--- a/dask-gateway/dask_gateway/dask_cli.py
+++ b/dask-gateway/dask_gateway/dask_cli.py
@@ -565,6 +565,9 @@ worker_parser.add_argument("--name", default=None, help="The worker name")
 worker_parser.add_argument(
     "--scheduler-address", default=None, help="The scheduler address"
 )
+worker_parser.add_argument(
+    "--no-nanny", action="store_false", dest="nanny", help="Do not use nanny for management"
+)
 
 
 async def start_worker(
@@ -612,6 +615,7 @@ def worker(argv=None):
     nthreads = args.nthreads
     memory_limit = args.memory_limit
     scheduler_address = args.scheduler_address
+    nanny = args.nanny
 
     gateway = make_gateway_client()
     security = make_security()
@@ -623,7 +627,7 @@ def worker(argv=None):
 
     async def run():
         worker = await start_worker(
-            gateway, security, worker_name, nthreads, memory_limit, scheduler_address
+            gateway, security, worker_name, nthreads, memory_limit, scheduler_address, nanny=nanny
         )
         await worker.finished()
 

--- a/tests/test_traitlets.py
+++ b/tests/test_traitlets.py
@@ -1,7 +1,7 @@
 import pytest
 from traitlets import HasTraits, TraitError
 
-from dask_gateway_server.traitlets import Type
+from dask_gateway_server.traitlets import Command, Type
 
 
 def test_Type_traitlet():
@@ -13,3 +13,15 @@ def test_Type_traitlet():
     assert "Failed to import" in str(exc.value)
 
     Foo(typ="dask_gateway_server.auth.SimpleAuthenticator")
+
+
+def test_Command_traitlet():
+    class C(HasTraits):
+        cmd = Command('default command')
+        cmd2 = Command(['default_cmd'])
+
+    c = C()
+    assert c.cmd == ['default command']
+    assert c.cmd2 == ['default_cmd']
+    c.cmd = 'foo bar'
+    assert c.cmd == ['foo bar']


### PR DESCRIPTION
I use --no-nanny for my dask clusters, and wonder if this is safe for a gateway cluster worker, as well.

One test was failing, but it was also failing prior to this change:
test_db_backend.py::test_idle_timeout
