### PR TITLE
Create dict gateway server option

### DIFF
--- a/dask-gateway-server/dask_gateway_server/options.py
+++ b/dask-gateway-server/dask_gateway_server/options.py
@@ -296,3 +296,33 @@ class Select(Field):
 
     def json_type_spec(self):
         return {"type": "select", "options": list(self.options)}
+
+
+@field_doc(
+    description="A dictionary field, allowing users to define cluster config dictionary fields",
+    params="""
+    default : string, optional
+        String to be assigned as dictionary value.    
+    label   : string, optional
+        Label used to define dictionary key.
+        Empty (None) value will assume field variable
+    eg.
+        Dict("s3fs pandas==1.0.5", default="", label="EXTRA_PIP_PACKAGES") 
+        ==> 
+        {"EXTRA_PIP_PACKAGES":  "s3fs pandas==1.0.5"}
+    """,
+)
+class Dict(String):
+    def __init__(self, field, default="", label=None):
+        self.label = label
+        super().__init__(field, default=default, label=label)
+
+    def validate(self, x):
+        if not isinstance(x, str):
+            raise TypeError(
+                "%s must be a str,  got %r" % (self.field, x)
+            )
+        return {self.label: x}
+
+    def json_type_spec(self):
+        return {"type": "dict"}

--- a/dask-gateway-server/dask_gateway_server/options.py
+++ b/dask-gateway-server/dask_gateway_server/options.py
@@ -312,7 +312,7 @@ class Select(Field):
         {"EXTRA_PIP_PACKAGES":  "s3fs pandas==1.0.5"}
     """,
 )
-class Dict(String):
+class Dict(Field):
     def __init__(self, field, default="", label=None):
         self.label = label
         super().__init__(field, default=default, label=label)

--- a/dask-gateway/dask_gateway/options.py
+++ b/dask-gateway/dask_gateway/options.py
@@ -316,3 +316,21 @@ class Select(Field):
         import ipywidgets
 
         return ipywidgets.Dropdown(value=self.value, options=self.options)
+
+
+@register_field_type("dict")
+class Dict(Field):
+    """A dict string option field"""
+    def __init__(self, field, default, label=None, options=None):
+        self.label=label
+        super().__init__(field, default, label=label)
+
+    def validate(self, x):
+        if not isinstance(x, str):
+            raise TypeError("%s must be a string, got %r" % (self.field, x))
+        return {self.label: x}
+
+    def _widget(self):
+        import ipywidgets
+
+        return ipywidgets.Text(value=self.value, continuous_update=False)


### PR DESCRIPTION
Create `Dict` gateway server option such that users can input environment variables via the ipython widget options.