### PR TITLE
Fix bug in idle cluster detection

### DIFF
--- a/dask-gateway/dask_gateway/dask_cli.py
+++ b/dask-gateway/dask_gateway/dask_cli.py
@@ -241,9 +241,9 @@ class GatewaySchedulerService(object):
         while True:
             await asyncio.sleep(self.idle_timeout / 4)
             if any(ws.processing for ws in self.scheduler.workers.values()):
-                return
+                continue
             if self.scheduler.unrunnable:
-                return
+                continue
 
             last_action = (
                 self.scheduler.transition_log[-1][-1]

--- a/tests/test_db_backend.py
+++ b/tests/test_db_backend.py
@@ -943,7 +943,11 @@ async def test_idle_timeout():
             cluster = await gateway.new_cluster()
             # Add some workers
             await cluster.scale(2)
-            await wait_for_workers(cluster, atleast=1)
+
+            # Schedule some work that takes enough time that the idle check
+            # will loop at least once
+            async with cluster.get_client(set_as_default=False) as client:
+                await client.submit(time.sleep, 1)
 
             waited = 0
             while await gateway.list_clusters():


### PR DESCRIPTION
Previously there was a bug where idle cluster detection only worked if the cluster never actually did any work. Our test cluster happened to never do any work, so tests pass and this went unnoticed. The test has now been updated, and the code fixed.

Fixes #279.