### PR TITLE
Add mapping option

### DIFF
--- a/docs/source/api-server.rst
+++ b/docs/source/api-server.rst
@@ -161,6 +161,8 @@ Cluster Manager Options
 
 .. autoclass:: dask_gateway_server.options.Select
 
+.. autoclass:: dask_gateway_server.options.Mapping
+
 
 Models
 ------

--- a/docs/source/cluster-options.rst
+++ b/docs/source/cluster-options.rst
@@ -81,6 +81,7 @@ different common type:
     ~dask_gateway_server.options.Bool
     ~dask_gateway_server.options.String
     ~dask_gateway_server.options.Select
+    ~dask_gateway_server.options.Mapping
 
 Each field supports the following standard parameters:
 


### PR DESCRIPTION
A cluster options that accepts a mapping. In the ipywidget we parse from yaml, which seems flexible and readable enough. On parse/validation error a red-x appears next to the textarea with a tooltip indicating the error. We also improve the general css of the input form.

Fixes #268, supersedes #284.