### PR TITLE
Enable cookies for IP hostnames

### DIFF
--- a/dask-gateway/dask_gateway/client.py
+++ b/dask-gateway/dask_gateway/client.py
@@ -379,7 +379,14 @@ class Gateway(object):
 
     async def _request(self, method, url, json=None):
         if self._session is None:
-            self._session = aiohttp.ClientSession()
+            # "unsafe" allows cookies to be set for ip addresses, which can
+            # commonly serve dask-gateway deployments. Since this client is
+            # only ever used with a single endpoint, there is no danger of
+            # leaking cookies to a different server that happens to have the
+            # same ip.
+            self._session = aiohttp.ClientSession(
+                cookie_jar=aiohttp.CookieJar(unsafe=True)
+            )
         session = self._session
 
         resp = await session.request(method, url, json=json, **self._request_kwargs)


### PR DESCRIPTION
By default aiohttp doesn't store cookies for urls with an IP address
instead of a DNS name. There's some debate if this is the correct
behavior based on reading of the spec, and for our use case (only ever
contacting a single server endpoint) storing cookies for an IP based url
shouldn't be any less secure. In certain deployments it may be more
common to have dask-gateway running behind an IP address than with an
explicit dns name.