### PR TITLE
Remove custom dask-gateway scheduler/worker CLIs

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -21,4 +21,4 @@ ignore =
 
 # black is set to 88, but isn't a strict limit so we add some wiggle room for
 # flake8 testing.
-max-line-length = 92
+max-line-length = 100

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,6 @@ branches:
   only:
     - master
 
-env:
-  global:
-    - secure: "kHo3xQM15V2soeT7tkOgyjIr+Iq3Dj7qvJO/3nHzOU0QluyewaHG5r1wQscyomQ9cSElCMkln3A0vtgeoDdslFnsMIhwUa7PXTZEIZYKb/tbP6WPntaqceHbgpzq27dw7Y4WVGZemDuyYblLKAYgyp5zbqYkoJb1YaIb+JGas2YF+mbVQF51Bk4mWyxlSc7AcKN0fi54GFq7PRjVCqkTI7uuY5MpPuPO+idX1tcmpsHf3rlpyOqlR4UiPv8w2JJCI5OOQf2DRCOOaDtItldFUaqzI5P/FY/MALA1p/ubvXrpoNgQaHPfRygqGQOsEOZnolg1gcRA8KjPA+Q04SCbZrx5G21CdGN5Kju1NeP3N7RXXJw5jl2zB51kwOf3msgIufds0gC/9ZGVks1lgpiHqwCG34ArUJo4omwYxg8z9ez7jT9vM2VCAdwwwUYmFWdmycld3lvn5MsvRbX2bVuee09rjwe2Sbj2+xBjg33CV5JDwv+rbI1JeYfD+EzXHI8MTj/O5DVINISqNO5ee3sQqJWnv1Fy/l5OSg6rugdNnkj4m1pPuqEGksj39W/m5FS3wBb4YXLQ+do/9aCFJIsQ8xnDw6BVVkwaTjyfhsNI+6vYQlkaTPVinRYyWUhSyApYcArw++NRycWglATS2zHCsZKiRF6Ass3Fs+/KFzkZ52k="
-
 jobs:
     fast_finish: true
 
@@ -87,6 +83,7 @@ jobs:
 
         - env:
             - DOCS=true
+            - secure: "kHo3xQM15V2soeT7tkOgyjIr+Iq3Dj7qvJO/3nHzOU0QluyewaHG5r1wQscyomQ9cSElCMkln3A0vtgeoDdslFnsMIhwUa7PXTZEIZYKb/tbP6WPntaqceHbgpzq27dw7Y4WVGZemDuyYblLKAYgyp5zbqYkoJb1YaIb+JGas2YF+mbVQF51Bk4mWyxlSc7AcKN0fi54GFq7PRjVCqkTI7uuY5MpPuPO+idX1tcmpsHf3rlpyOqlR4UiPv8w2JJCI5OOQf2DRCOOaDtItldFUaqzI5P/FY/MALA1p/ubvXrpoNgQaHPfRygqGQOsEOZnolg1gcRA8KjPA+Q04SCbZrx5G21CdGN5Kju1NeP3N7RXXJw5jl2zB51kwOf3msgIufds0gC/9ZGVks1lgpiHqwCG34ArUJo4omwYxg8z9ez7jT9vM2VCAdwwwUYmFWdmycld3lvn5MsvRbX2bVuee09rjwe2Sbj2+xBjg33CV5JDwv+rbI1JeYfD+EzXHI8MTj/O5DVINISqNO5ee3sQqJWnv1Fy/l5OSg6rugdNnkj4m1pPuqEGksj39W/m5FS3wBb4YXLQ+do/9aCFJIsQ8xnDw6BVVkwaTjyfhsNI+6vYQlkaTPVinRYyWUhSyApYcArw++NRycWglATS2zHCsZKiRF6Ass3Fs+/KFzkZ52k="
           before_install:
             - source continuous_integration/before_install.sh
           install:

--- a/dask-gateway-server/dask_gateway_server/backends/base.py
+++ b/dask-gateway-server/dask_gateway_server/backends/base.py
@@ -242,15 +242,11 @@ class ClusterConfig(Configurable):
     """Base class for holding individual Dask cluster configurations"""
 
     scheduler_cmd = Command(
-        "dask-gateway-scheduler",
-        help="Shell command to start a dask-gateway scheduler.",
-        config=True,
+        "dask-scheduler", help="Shell command to start a dask scheduler.", config=True,
     )
 
     worker_cmd = Command(
-        "dask-gateway-worker",
-        help="Shell command to start a dask-gateway worker.",
-        config=True,
+        "dask-worker", help="Shell command to start a dask worker.", config=True,
     )
 
     environment = Dict(

--- a/dask-gateway-server/dask_gateway_server/backends/db_base.py
+++ b/dask-gateway-server/dask_gateway_server/backends/db_base.py
@@ -1416,7 +1416,7 @@ class DBBackendBase(Backend):
         )
         return env
 
-    scheduler_host = ""
+    default_host = ""
 
     def get_scheduler_command(self, cluster):
         return cluster.config.scheduler_cmd + [
@@ -1425,13 +1425,13 @@ class DBBackendBase(Backend):
             "--port",
             "0",
             "--host",
-            self.scheduler_host,
+            self.default_host,
             "--dashboard-address",
-            f"{self.scheduler_host}:0",
-            "--dg-api-address",
-            f"{self.scheduler_host}:0",
+            f"{self.default_host}:0",
             "--preload",
             "dask_gateway.scheduler_preload",
+            "--dg-api-address",
+            f"{self.default_host}:0",
             "--dg-heartbeat-period",
             str(self.cluster_heartbeat_period),
             "--dg-adaptive-period",
@@ -1449,6 +1449,8 @@ class DBBackendBase(Backend):
             scheduler_address = cluster.scheduler_address
         return cluster.config.worker_cmd + [
             scheduler_address,
+            "--dashboard-address",
+            f"{self.default_host}:0",
             "--name",
             worker_name,
             "--nthreads",

--- a/dask-gateway-server/dask_gateway_server/backends/db_base.py
+++ b/dask-gateway-server/dask_gateway_server/backends/db_base.py
@@ -1416,7 +1416,7 @@ class DBBackendBase(Backend):
         )
         return env
 
-    default_host = ""
+    default_host = "0.0.0.0"
 
     def get_scheduler_command(self, cluster):
         return cluster.config.scheduler_cmd + [

--- a/dask-gateway-server/dask_gateway_server/backends/db_base.py
+++ b/dask-gateway-server/dask_gateway_server/backends/db_base.py
@@ -1381,31 +1381,81 @@ class DBBackendBase(Backend):
     def get_env(self, cluster):
         """Get a dict of environment variables to set for the process"""
         out = dict(cluster.config.environment)
-        tls_cert_path, tls_key_path = self.get_tls_paths(cluster)
         # Set values that dask-gateway needs to run
         out.update(
             {
                 "DASK_GATEWAY_API_URL": self.api_url,
                 "DASK_GATEWAY_API_TOKEN": cluster.token,
                 "DASK_GATEWAY_CLUSTER_NAME": cluster.name,
-                "DASK_GATEWAY_TLS_CERT": tls_cert_path,
-                "DASK_GATEWAY_TLS_KEY": tls_key_path,
+                "DASK_DISTRIBUTED__COMM__REQUIRE_ENCRYPTION": "True",
             }
         )
         return out
 
+    def get_scheduler_env(self, cluster):
+        env = self.get_env(cluster)
+        tls_cert_path, tls_key_path = self.get_tls_paths(cluster)
+        env.update(
+            {
+                "DASK_DISTRIBUTED__COMM__TLS__CA_FILE": tls_cert_path,
+                "DASK_DISTRIBUTED__COMM__TLS__SCHEDULER__KEY": tls_key_path,
+                "DASK_DISTRIBUTED__COMM__TLS__SCHEDULER__CERT": tls_cert_path,
+            }
+        )
+        return env
+
+    def get_worker_env(self, cluster):
+        env = self.get_env(cluster)
+        tls_cert_path, tls_key_path = self.get_tls_paths(cluster)
+        env.update(
+            {
+                "DASK_DISTRIBUTED__COMM__TLS__CA_FILE": tls_cert_path,
+                "DASK_DISTRIBUTED__COMM__TLS__WORKER__KEY": tls_key_path,
+                "DASK_DISTRIBUTED__COMM__TLS__WORKER__CERT": tls_cert_path,
+            }
+        )
+        return env
+
+    scheduler_host = ""
+
     def get_scheduler_command(self, cluster):
         return cluster.config.scheduler_cmd + [
-            "--heartbeat-period",
+            "--protocol",
+            "tls",
+            "--port",
+            "0",
+            "--host",
+            self.scheduler_host,
+            "--dashboard-address",
+            f"{self.scheduler_host}:0",
+            "--dg-api-address",
+            f"{self.scheduler_host}:0",
+            "--preload",
+            "dask_gateway.scheduler_preload",
+            "--dg-heartbeat-period",
             str(self.cluster_heartbeat_period),
-            "--adaptive-period",
+            "--dg-adaptive-period",
             str(cluster.config.adaptive_period),
-            "--idle-timeout",
+            "--dg-idle-timeout",
             str(cluster.config.idle_timeout),
         ]
 
-    def get_worker_command(self, cluster):
-        return cluster.config.worker_cmd
+    def worker_nthreads_memory_limit_args(self, cluster):
+        return str(cluster.config.worker_cores), str(cluster.config.worker_memory)
+
+    def get_worker_command(self, cluster, worker_name, scheduler_address=None):
+        nthreads, memory_limit = self.worker_nthreads_memory_limit_args(cluster)
+        if scheduler_address is None:
+            scheduler_address = cluster.scheduler_address
+        return cluster.config.worker_cmd + [
+            scheduler_address,
+            "--name",
+            worker_name,
+            "--nthreads",
+            nthreads,
+            "--memory-limit",
+            memory_limit,
+        ]
 
     # Subclasses should implement these methods
     supports_bulk_shutdown = False

--- a/dask-gateway-server/dask_gateway_server/backends/jobqueue/base.py
+++ b/dask-gateway-server/dask_gateway_server/backends/jobqueue/base.py
@@ -188,7 +188,7 @@ class JobQueueBackend(DBBackendBase):
             await self.stop_job(cluster.username, job_id, staging_dir=staging_dir)
 
     async def do_start_worker(self, worker):
-        cmd, env, stdin = self.get_submit_cmd_env_stdin(worker.cluster, worker.name)
+        cmd, env, stdin = self.get_submit_cmd_env_stdin(worker.cluster, worker)
         job_id = await self.start_job(worker.cluster.username, cmd, env, stdin)
         self.log.info("Job %s submitted for worker %s", job_id, worker.name)
         yield {"job_id": job_id}

--- a/dask-gateway-server/dask_gateway_server/backends/jobqueue/base.py
+++ b/dask-gateway-server/dask_gateway_server/backends/jobqueue/base.py
@@ -60,7 +60,7 @@ class JobQueueBackend(DBBackendBase):
 
     status_command = Unicode(help="The path to the job status command", config=True)
 
-    def get_submit_cmd_env_stdin(self, cluster, worker_name=None):
+    def get_submit_cmd_env_stdin(self, cluster, worker=None):
         raise NotImplementedError
 
     def get_stop_cmd_env(self, job_id):

--- a/dask-gateway-server/dask_gateway_server/backends/local.py
+++ b/dask-gateway-server/dask_gateway_server/backends/local.py
@@ -134,6 +134,8 @@ class LocalBackend(DBBackendBase):
         config=True,
     )
 
+    scheduler_host = "127.0.0.1"
+
     def set_file_permissions(self, paths, username):
         pwnam = getpwnam(username)
         for p in paths:
@@ -215,20 +217,6 @@ class LocalBackend(DBBackendBase):
         env["USER"] = cluster.username
         return env
 
-    def get_scheduler_command(self, cluster):
-        cmd = super().get_scheduler_command(cluster)
-        cmd.extend(
-            [
-                "--scheduler-address",
-                "tls://127.0.0.1:0",
-                "--dashboard-address",
-                "127.0.0.1:0",
-                "--api-address",
-                "127.0.0.1:0",
-            ]
-        )
-        return cmd
-
     async def start_process(self, cluster, cmd, env, name):
         workdir = cluster.state["workdir"]
         logsdir = self.get_logs_directory(workdir)
@@ -242,7 +230,7 @@ class LocalBackend(DBBackendBase):
                 preexec_fn=self.make_preexec_fn(cluster),
                 start_new_session=True,
                 env=env,
-                stdout=fd,
+                # stdout=fd,
                 stderr=asyncio.subprocess.STDOUT,
             )
         finally:
@@ -274,7 +262,7 @@ class LocalBackend(DBBackendBase):
         pid = await self.start_process(
             cluster,
             self.get_scheduler_command(cluster),
-            self.get_env(cluster),
+            self.get_scheduler_env(cluster),
             "scheduler",
         )
         yield {"workdir": workdir, "pid": pid}
@@ -296,9 +284,8 @@ class LocalBackend(DBBackendBase):
         return [self._check_status(c) for c in clusters]
 
     async def do_start_worker(self, worker):
-        cmd = self.get_worker_command(worker.cluster)
-        env = self.get_env(worker.cluster)
-        env["DASK_GATEWAY_WORKER_NAME"] = worker.name
+        cmd = self.get_worker_command(worker.cluster, worker.name)
+        env = self.get_worker_env(worker.cluster)
         pid = await self.start_process(
             worker.cluster, cmd, env, "worker-%s" % worker.name
         )

--- a/dask-gateway-server/dask_gateway_server/backends/local.py
+++ b/dask-gateway-server/dask_gateway_server/backends/local.py
@@ -134,7 +134,7 @@ class LocalBackend(DBBackendBase):
         config=True,
     )
 
-    scheduler_host = "127.0.0.1"
+    default_host = "127.0.0.1"
 
     def set_file_permissions(self, paths, username):
         pwnam = getpwnam(username)
@@ -230,7 +230,7 @@ class LocalBackend(DBBackendBase):
                 preexec_fn=self.make_preexec_fn(cluster),
                 start_new_session=True,
                 env=env,
-                # stdout=fd,
+                stdout=fd,
                 stderr=asyncio.subprocess.STDOUT,
             )
         finally:

--- a/dask-gateway-server/dask_gateway_server/routes.py
+++ b/dask-gateway-server/dask_gateway_server/routes.py
@@ -276,20 +276,3 @@ async def handle_heartbeat(request):
     except PublicException as exc:
         raise web.HTTPConflict(reason=str(exc))
     return web.Response()
-
-
-@default_routes.get("/api/v1/clusters/{cluster_name}/addresses")
-@api_handler(token_authenticated=True)
-async def handle_addresses(request):
-    cluster_name = request.match_info["cluster_name"]
-    backend = request.app["backend"]
-    cluster = await backend.get_cluster(cluster_name)
-    if cluster is None:
-        raise web.HTTPNotFound(reason=f"Cluster {cluster_name} not found")
-    return web.json_response(
-        {
-            "api_address": cluster.api_address,
-            "dashboard_address": cluster.dashboard_address,
-            "scheduler_address": cluster.scheduler_address,
-        }
-    )

--- a/dask-gateway-server/setup.cfg
+++ b/dask-gateway-server/setup.cfg
@@ -19,4 +19,4 @@ ignore =
 
 # black is set to 88, but isn't a strict limit so we add some wiggle room for
 # flake8 testing.
-max-line-length = 92
+max-line-length = 100

--- a/dask-gateway/setup.cfg
+++ b/dask-gateway/setup.cfg
@@ -19,4 +19,4 @@ ignore =
 
 # black is set to 88, but isn't a strict limit so we add some wiggle room for
 # flake8 testing.
-max-line-length = 92
+max-line-length = 100

--- a/dask-gateway/setup.py
+++ b/dask-gateway/setup.py
@@ -48,11 +48,5 @@ setup(
     package_data={"dask_gateway": ["*.yaml"]},
     install_requires=install_requires,
     extras_require=extras_require,
-    entry_points={
-        "console_scripts": [
-            "dask-gateway-scheduler = dask_gateway.dask_cli:scheduler",
-            "dask-gateway-worker = dask_gateway.dask_cli:worker",
-        ]
-    },
     zip_safe=False,
 )

--- a/docs/source/install-hadoop.rst
+++ b/docs/source/install-hadoop.rst
@@ -245,9 +245,9 @@ done a few different ways:
 
 .. code-block:: python
 
-    # Configure the paths to the dask-gateway-scheduler/dask-gateway-worker CLIs
-    c.YarnClusterConfig.scheduler_cmd = "/path/to/dask-gateway-scheduler"
-    c.YarnClusterConfig.worker_cmd = "/path/to/dask-gateway-worker"
+    # Configure the paths to the dask-scheduler/dask-worker CLIs
+    c.YarnClusterConfig.scheduler_cmd = "/path/to/dask-scheduler"
+    c.YarnClusterConfig.worker_cmd = "/path/to/dask-worker"
 
     # OR
     # Activate a local conda environment before startup

--- a/docs/source/install-jobqueue.rst
+++ b/docs/source/install-jobqueue.rst
@@ -193,9 +193,9 @@ the provided Python. This could be done a few different ways:
 
 .. code-block:: python
 
-    # Configure the paths to the dask-gateway-scheduler/dask-gateway-worker CLIs
-    c.JobQueueClusterConfig.scheduler_cmd = "/path/to/dask-gateway-scheduler"
-    c.JobQueueClusterConfig.worker_cmd = "/path/to/dask-gateway-worker"
+    # Configure the paths to the dask-scheduler/dask-worker CLIs
+    c.JobQueueClusterConfig.scheduler_cmd = "/path/to/dask-scheduler"
+    c.JobQueueClusterConfig.worker_cmd = "/path/to/dask-worker"
 
     # OR
     # Activate a local conda environment before startup
@@ -276,9 +276,9 @@ look like:
     # Configure the gateway to use PBS as the backend
     c.DaskGateway.backend_class = "dask_gateway_server.backends.pbs.PBSBackend"
 
-    # Configure the paths to the dask-gateway-scheduler/dask-gateway-worker CLIs
-    c.PBSClusterConfig.scheduler_cmd = "~/miniconda/bin/dask-gateway-scheduler"
-    c.PBSClusterConfig.worker_cmd = "~/miniconda/bin/dask-gateway-worker"
+    # Configure the paths to the dask-scheduler/dask-worker CLIs
+    c.PBSClusterConfig.scheduler_cmd = "~/miniconda/bin/dask-scheduler"
+    c.PBSClusterConfig.worker_cmd = "~/miniconda/bin/dask-worker"
 
     # Limit resources for a single worker
     c.PBSClusterConfig.worker_memory = '4 G'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,10 +1,8 @@
 import os
 import pytest
 
-from dask_gateway_server import __version__ as VERSION
 from dask_gateway_server.app import DaskGateway
 from dask_gateway_server.proxy.core import ProxyApp, _PROXY_EXE
-from dask_gateway.dask_cli import worker, scheduler
 
 
 def test_generate_config(tmpdir, capfd):
@@ -80,20 +78,3 @@ def test_proxy_cli(tmpdir, monkeypatch):
     ]
 
     assert "DASK_GATEWAY_PROXY_TOKEN" in env
-
-
-@pytest.mark.parametrize("cmd", [scheduler, worker])
-def test_dask_gateway_dask_cli(cmd, capfd):
-    with pytest.raises(SystemExit) as exc:
-        cmd(["--help"])
-    assert not exc.value.code
-    out, err = capfd.readouterr()
-    assert out
-    assert not err
-
-    with pytest.raises(SystemExit) as exc:
-        cmd(["--version"])
-    assert not exc.value.code
-    out, err = capfd.readouterr()
-    assert VERSION in out
-    assert not err

--- a/tests/test_pbs_backend.py
+++ b/tests/test_pbs_backend.py
@@ -62,8 +62,8 @@ class PBSTestingBackend(PBSBackend):
 @pytest.mark.asyncio
 async def test_pbs_backend():
     c = Config()
-    c.PBSClusterConfig.scheduler_cmd = "/opt/miniconda/bin/dask-gateway-scheduler"
-    c.PBSClusterConfig.worker_cmd = "/opt/miniconda/bin/dask-gateway-worker"
+    c.PBSClusterConfig.scheduler_cmd = "/opt/miniconda/bin/dask-scheduler"
+    c.PBSClusterConfig.worker_cmd = "/opt/miniconda/bin/dask-worker"
     c.PBSClusterConfig.scheduler_memory = "256M"
     c.PBSClusterConfig.worker_memory = "256M"
     c.PBSClusterConfig.scheduler_cores = 1

--- a/tests/test_slurm_backend.py
+++ b/tests/test_slurm_backend.py
@@ -69,8 +69,8 @@ class SlurmTestingBackend(SlurmBackend):
 async def test_slurm_backend():
     c = Config()
 
-    c.SlurmClusterConfig.scheduler_cmd = "/opt/miniconda/bin/dask-gateway-scheduler"
-    c.SlurmClusterConfig.worker_cmd = "/opt/miniconda/bin/dask-gateway-worker"
+    c.SlurmClusterConfig.scheduler_cmd = "/opt/miniconda/bin/dask-scheduler"
+    c.SlurmClusterConfig.worker_cmd = "/opt/miniconda/bin/dask-worker"
     c.SlurmClusterConfig.scheduler_memory = "256M"
     c.SlurmClusterConfig.worker_memory = "256M"
     c.SlurmClusterConfig.scheduler_cores = 1

--- a/tests/test_yarn_backend.py
+++ b/tests/test_yarn_backend.py
@@ -52,8 +52,8 @@ class YarnTestingBackend(YarnBackend):
 async def test_yarn_backend():
 
     c = Config()
-    c.YarnClusterConfig.scheduler_cmd = "/opt/miniconda/bin/dask-gateway-scheduler"
-    c.YarnClusterConfig.worker_cmd = "/opt/miniconda/bin/dask-gateway-worker"
+    c.YarnClusterConfig.scheduler_cmd = "/opt/miniconda/bin/dask-scheduler"
+    c.YarnClusterConfig.worker_cmd = "/opt/miniconda/bin/dask-worker"
     c.YarnClusterConfig.scheduler_memory = "512M"
     c.YarnClusterConfig.worker_memory = "512M"
     c.YarnClusterConfig.scheduler_cores = 1


### PR DESCRIPTION
Previously dask-gateway relied upon custom scheduler/worker CLIs for
integrating with the backend system. While simple to write, this
resulted in a few complications:

- Extra CLI arguments had to be added to support unexposed options
- Users couldn't swap out the dask-worker for a dask-cuda-worker

This PR removes the custom scheduler/worker CLIs in favor of relying on
a preload script, and altering slightly the communication patterns to
avoid the need for anything custom in the workers.

Fixes #177