### PR TITLE
Pass public_address to creation of new cluster

### DIFF
--- a/dask-gateway/dask_gateway/client.py
+++ b/dask-gateway/dask_gateway/client.py
@@ -635,6 +635,7 @@ class Gateway(object):
         return GatewayCluster(
             address=self.address,
             proxy_address=self.proxy_address,
+            public_address=self._public_address,
             auth=self.auth,
             asynchronous=self.asynchronous,
             loop=self.loop,


### PR DESCRIPTION
Currently a cluster created by a gateway with a `public_address` different from `address` doesn't inherit it.

Currently I need this workaround:

```
cluster = gateway.new_cluster(public_address = gateway._public_address)
```