### PR TITLE
feat: add ability to build docker images using python 3.8

### DIFF
--- a/dask-gateway-server/Dockerfile
+++ b/dask-gateway-server/Dockerfile
@@ -1,4 +1,5 @@
-FROM daskgateway/dask-gateway-base:0.7.1 AS dependencies
+ARG base_image=daskgateway/dask-gateway-base:0.7.1
+FROM ${base_image} as dependencies
 LABEL MAINTAINER="Jim Crist-Harif"
 
 # Install dependencies

--- a/dask-gateway/Dockerfile
+++ b/dask-gateway/Dockerfile
@@ -1,4 +1,5 @@
-FROM daskgateway/dask-gateway-base:0.7.1 as dependencies
+ARG base_image=daskgateway/dask-gateway-base:0.7.1
+FROM ${base_image} as dependencies
 LABEL MAINTAINER="Jim Crist-Harif"
 
 # Does the following in one layer

--- a/resources/helm/images/dask-gateway-base/Dockerfile
+++ b/resources/helm/images/dask-gateway-base/Dockerfile
@@ -1,8 +1,16 @@
-FROM debian:10.4-slim
+# python 3.8: -> python:3.8-slim-buster
+ARG base_image=debian:10.4-slim
+FROM ${base_image}
+# FROM python:3.8-slim-buster
 LABEL MAINTAINER="Jim Crist-Harif"
 
-ENV CONDA_VERSION py37_4.8.3
-ENV CONDA_SHA256 bb2e3cedd2e78a8bb6872ab3ab5b1266a90f8c7004a22d8dc2ea5effeb6a439a
+# python 3.8: -> py38_4.8.3
+ARG conda_version=py37_4.8.3
+# pythom 3.8" -> 879457af6a0bf5b34b48c12de31d4df0ee2f06a8e68768e5758c3293b2daf688
+ARG conda_sha256=bb2e3cedd2e78a8bb6872ab3ab5b1266a90f8c7004a22d8dc2ea5effeb6a439a
+ENV CONDA_VERSION ${conda_version}
+ENV CONDA_SHA256 ${conda_sha256}
+ENV DEBIAN_FRONTEND noninteractive
 
 # We do the following all in one block:
 # - Create user dask

--- a/resources/helm/images/dask-gateway-base/build_python3.8.sh
+++ b/resources/helm/images/dask-gateway-base/build_python3.8.sh
@@ -1,0 +1,5 @@
+# Build docker image with arguments appropriate for python3.8
+#
+# $1 should be tag for image
+tag=${1:=daskgateway/dask-gateway:0.7.1-py38}
+docker build --build-arg base_image=python:3.8-slim-buster --build-arg conda_version=py38_4.8.3 --build-arg conda_sha256=879457af6a0bf5b34b48c12de31d4df0ee2f06a8e68768e5758c3293b2daf688  -t $tag .


### PR DESCRIPTION
Not sure if you were looking for this ability -- but, just in case, this adds:
* docker ARGs to `dask-gateway-base` to switch base image and Miniconda version
* docker ARGs to`dask-gateway` and `dask-gateway-server` to switch base image (to take advantage of above)
* simple script to build `dask-gateway-base` using `python:3.8-slim-buster` base and appropriate Miniconda version for python 3.8 support.

Does not address CI/CD or testing of built images. I did use to build my own base image that does use python3.8 and looks successful (preliminarily).

Passing in of the base could be useful separately. (For instance, I usually use ubuntu for python images.)