### PR TITLE
feat: add imagePullSecrets option to values for gateway and controller

### DIFF
--- a/resources/helm/dask-gateway/templates/controller/deployment.yaml
+++ b/resources/helm/dask-gateway/templates/controller/deployment.yaml
@@ -35,6 +35,10 @@ spec:
         - name: configmap
           configMap:
             name: {{ include "dask-gateway.controllerName" . }}
+      {{- with .Values.controller.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: controller
           image: {{ .Values.controller.image.name }}:{{ .Values.controller.image.tag }}

--- a/resources/helm/dask-gateway/templates/gateway/deployment.yaml
+++ b/resources/helm/dask-gateway/templates/gateway/deployment.yaml
@@ -33,6 +33,10 @@ spec:
         - name: configmap
           configMap:
             name: {{ include "dask-gateway.apiName" . }}
+      {{- with .Values.gateway.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: gateway
           image: {{ .Values.gateway.image.name }}:{{ .Values.gateway.image.tag }}

--- a/resources/helm/dask-gateway/values.yaml
+++ b/resources/helm/dask-gateway/values.yaml
@@ -22,6 +22,9 @@ gateway:
     tag: 0.8.0
     pullPolicy: IfNotPresent
 
+  # Image pull secrets for gateway-server pod
+  imagePullSecrets: []
+
   # Configuration for the gateway-server service
   service:
     annotations: {}
@@ -141,6 +144,9 @@ controller:
 
   # Resource requests/limits for the controller pod
   resources: {}
+
+  # Image pull secrets for controller pod
+  imagePullSecrets: []
 
   # The controller log level
   loglevel: INFO


### PR DESCRIPTION
As an alternative to adding "imagePullSecrets", one could have "extraPodConfig" as you do with worker and scheduler. That seemed to me like too large a change in the templates. 

Putatively, I could use an external service account instead for pull secrets, but then would have to track the needed role bindings if they changed. In theory, imagePullSecrets option could be added to the default service account config as well or instead.