### PR TITLE
Fix docs formatting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,7 +88,7 @@ jobs:
             - source continuous_integration/before_install.sh
           install:
             - source continuous_integration/install.sh
-            - pip install kubernetes_asyncio skein sphinx doctr dask-sphinx-theme
+            - pip install kubernetes_asyncio skein sphinx doctr dask-sphinx-theme sphinx-rtd-theme==0.4.3
           script:
             - |
               set -xe

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -34,4 +34,3 @@ extlinks = {
 # Sphinx Theme
 html_theme = "dask_sphinx_theme"
 templates_path = ["_templates"]
-html_static_path = ["_static"]


### PR DESCRIPTION
Something about `sphinx-rtd-theme==0.5.0` breaks api doc rendering. For
now we pin to 0.4.3.

Fixes #292.