### PR TITLE
Add Gateway and Controller affinities, nodeSelector, tolerations

### DIFF
--- a/continuous_integration/kubernetes/script.sh
+++ b/continuous_integration/kubernetes/script.sh
@@ -1,2 +1,4 @@
 #!/usr/bin/env bash
 TEST_DASK_GATEWAY_KUBE=true TEST_DASK_GATEWAY_KUBE_ADDRESS=http://localhost:30200/services/dask-gateway/ py.test tests/kubernetes/ -vv
+
+helm install --dry-run --debug --generate-name resources/helm/dask-gateway/ -f continuous_integration/kubernetes/test_config.yaml

--- a/continuous_integration/kubernetes/test_config.yaml
+++ b/continuous_integration/kubernetes/test_config.yaml
@@ -1,0 +1,32 @@
+gateway:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: kubernetes.io/e2e-az-name
+            operator: In
+            values:
+            - e2e-az1
+
+controller:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: kubernetes.io/e2e-az-name
+            operator: In
+            values:
+            - e2e-az1
+
+traefik:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: kubernetes.io/e2e-az-name
+            operator: In
+            values:
+            - e2e-az1

--- a/resources/helm/dask-gateway/templates/controller/deployment.yaml
+++ b/resources/helm/dask-gateway/templates/controller/deployment.yaml
@@ -52,4 +52,16 @@ spec:
           ports:
             - containerPort: 8000
               name: api
+      {{- with .Values.controller.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controller.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/resources/helm/dask-gateway/templates/gateway/deployment.yaml
+++ b/resources/helm/dask-gateway/templates/gateway/deployment.yaml
@@ -79,3 +79,15 @@ spec:
             timeoutSeconds: {{ .Values.gateway.readinessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.gateway.readinessProbe.failureThreshold }}
           {{- end }}
+      {{- with .Values.gateway.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.gateway.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.gateway.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/resources/helm/dask-gateway/values.yaml
+++ b/resources/helm/dask-gateway/values.yaml
@@ -123,6 +123,11 @@ gateway:
         request: null
         limit: null
 
+  # Settings for nodeSelector, affinity, and tolerations for the gateway pods
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+
   # Any extra configuration code to append to the generated `dask_gateway_config.py`
   # file. Can be either a single code-block, or a map of key -> code-block
   # (code-blocks are run in alphabetical order by key, the key value itself is
@@ -170,6 +175,11 @@ controller:
     name: daskgateway/dask-gateway-server
     tag: 0.8.0
     pullPolicy: IfNotPresent
+
+  # Settings for nodeSelector, affinity, and tolerations for the controller pods
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
 
 # Configuration for the traefik proxy
 traefik:


### PR DESCRIPTION
This PR allows setting the affinities, nodeSelector, and tolerations for the Gateway and Controller pods. I may be wrong, but I didn't see a way to do that from the `extraConfig`.

It also adds a very basic test, ensuring that the helm chart can be deployed with `--dry-run`. That would have caught the other helm issue. I can remove it if we don't think it's useful (or expand it to cover other things if you want). Apparently helm has some tools for testing charts, though I've never used them before.