### PR TITLE
Add optional `user` to cluster options handler

### DIFF
--- a/dask-gateway-server/dask_gateway_server/backends/base.py
+++ b/dask-gateway-server/dask_gateway_server/backends/base.py
@@ -96,7 +96,7 @@ class Backend(LoggingConfigurable):
         try:
             cluster_options = await self.get_cluster_options(user)
             requested_options = cluster_options.parse_options(request)
-            overrides = cluster_options.get_configuration(requested_options)
+            overrides = cluster_options.get_configuration(requested_options, user)
             config = self.cluster_config_class(parent=self, **overrides)
         except asyncio.CancelledError:
             raise


### PR DESCRIPTION
The `handler` function provided to the `Options` object for
`cluster_options` can now take an optional `user` argument. This can be
used to provide user-specific configuration, without requiring stashing
the `user` in a closure from `cluster_options`.

Fixes #306.