### PR TITLE
Log requests at different levels

### DIFF
--- a/dask-gateway-server/dask_gateway_server/utils.py
+++ b/dask-gateway-server/dask_gateway_server/utils.py
@@ -195,7 +195,15 @@ class LogFormatter(ColoredFormatter):
 
 class AccessLogger(aiohttp.abc.AbstractAccessLogger):
     def log(self, request, response, time):
-        self.logger.info(
+        if response.status >= 500:
+            level = self.logger.error
+        elif response.status >= 400:
+            level = self.logger.warning
+        elif request.path.endswith("/api/health"):
+            level = self.logger.debug
+        else:
+            level = self.logger.info
+        level(
             "%d %s %s %.3fms",
             response.status,
             request.method,


### PR DESCRIPTION
Previously all access logs were logged at `INFO` level. This produced
too much log output. We now log requests at different levels based on
their properties:
- 500 errors logged at `ERROR`
- 400 errors logged at `WARNING`
- health checks logged at `DEBUG`
- everything else logged at `INFO`

The health checks in particular are quite noisy, so running the server
with a log level of `INFO` should be more acceptable now.

Fixes #328.