### PR TITLE
Add LSF scheduler backend

### DIFF
--- a/dask-gateway-server/dask-gateway-proxy/fail_without_go_1_12.go
+++ b/dask-gateway-server/dask-gateway-proxy/fail_without_go_1_12.go
@@ -1,7 +1,7 @@
-// +build !go1.12
+// +build !go1.11
 
 package main
 
 func compileTimeError() {
-	GO_1_12_REQUIRED_FOR_BUILD
+	GO_1_11_REQUIRED_FOR_BUILD
 }

--- a/dask-gateway-server/dask-gateway-proxy/fail_without_go_1_12.go
+++ b/dask-gateway-server/dask-gateway-proxy/fail_without_go_1_12.go
@@ -1,7 +1,7 @@
-// +build !go1.11
+// +build !go1.12
 
 package main
 
 func compileTimeError() {
-	GO_1_11_REQUIRED_FOR_BUILD
+	GO_1_12_REQUIRED_FOR_BUILD
 }

--- a/dask-gateway-server/dask_gateway_server/backends/db_base.py
+++ b/dask-gateway-server/dask_gateway_server/backends/db_base.py
@@ -807,6 +807,24 @@ class DBBackendBase(Backend):
         config=True,
     )
 
+    scheduler_port = Integer(
+        default=0,
+        help="""
+        The internally used port the dask schedulers will listen for connections on. If not specified,
+        each scheduler will chose a random port.
+        """,
+        config=True,
+    )
+
+    dashboard_port = Integer(
+        default=0,
+        help="""
+        The internally used port the dask schedulers expose the bokeh dashboard on. If not specified,
+        each scheduler will chose a random port.
+        """,
+        config=True,
+    )
+
     @default("api_url")
     def _api_url_default(self):
         proxy = self.proxy
@@ -1425,11 +1443,11 @@ class DBBackendBase(Backend):
             "--protocol",
             "tls",
             "--port",
-            "0",
+            f"{self.scheduler_port}",
             "--host",
             self.default_host,
             "--dashboard-address",
-            f"{self.default_host}:0",
+            f"{self.default_host}:{self.dashboard_port}",
             "--preload",
             "dask_gateway.scheduler_preload",
             "--dg-api-address",

--- a/dask-gateway-server/dask_gateway_server/backends/db_base.py
+++ b/dask-gateway-server/dask_gateway_server/backends/db_base.py
@@ -825,6 +825,15 @@ class DBBackendBase(Backend):
         config=True,
     )
 
+    dg_api_port = Integer(
+        default=0,
+        help="""
+        The internally used port the dask schedulers use for the gateway API. If not specified,
+        each scheduler will chose a random port.
+        """,
+        config=True,
+    )
+
     @default("api_url")
     def _api_url_default(self):
         proxy = self.proxy
@@ -1451,7 +1460,7 @@ class DBBackendBase(Backend):
             "--preload",
             "dask_gateway.scheduler_preload",
             "--dg-api-address",
-            f"{self.default_host}:0",
+            f"{self.default_host}:{self.dg_api_port}",
             "--dg-heartbeat-period",
             str(self.cluster_heartbeat_period),
             "--dg-adaptive-period",

--- a/dask-gateway-server/dask_gateway_server/backends/db_base.py
+++ b/dask-gateway-server/dask_gateway_server/backends/db_base.py
@@ -1404,6 +1404,7 @@ class DBBackendBase(Backend):
                 "DASK_DISTRIBUTED__COMM__TLS__SCHEDULER__CERT": tls_cert_path,
             }
         )
+        print(env)
         return env
 
     def get_worker_env(self, cluster):

--- a/dask-gateway-server/dask_gateway_server/backends/db_base.py
+++ b/dask-gateway-server/dask_gateway_server/backends/db_base.py
@@ -1404,7 +1404,6 @@ class DBBackendBase(Backend):
                 "DASK_DISTRIBUTED__COMM__TLS__SCHEDULER__CERT": tls_cert_path,
             }
         )
-        print(env)
         return env
 
     def get_worker_env(self, cluster):

--- a/dask-gateway-server/dask_gateway_server/backends/jobqueue/base.py
+++ b/dask-gateway-server/dask_gateway_server/backends/jobqueue/base.py
@@ -96,7 +96,7 @@ class JobQueueBackend(DBBackendBase):
         return cert_path, key_path
 
     async def do_as_user(self, user, action, **kwargs):
-        #cmd = ["sudo", "-nHu", user, self.dask_gateway_jobqueue_launcher]
+        cmd = ["sudo", "-nHu", user, self.dask_gateway_jobqueue_launcher]
         kwargs["action"] = action
         proc = await asyncio.create_subprocess_exec(
             *cmd,

--- a/dask-gateway-server/dask_gateway_server/backends/jobqueue/launcher.py
+++ b/dask-gateway-server/dask_gateway_server/backends/jobqueue/launcher.py
@@ -17,6 +17,9 @@ def run_command(cmd, env, stdin=None):
     else:
         STDIN = None
 
+    # forward base environment
+    env.update(os.environ.copy())
+
     proc = subprocess.Popen(
         cmd,
         env=env,
@@ -57,7 +60,8 @@ def stop(cmd, env, staging_dir=None):
         if not os.path.exists(staging_dir):
             return
         try:
-            shutil.rmtree(staging_dir)
+            #shutil.rmtree(staging_dir)
+            pass
         except Exception as exc:
             finish(
                 ok=False,

--- a/dask-gateway-server/dask_gateway_server/backends/jobqueue/launcher.py
+++ b/dask-gateway-server/dask_gateway_server/backends/jobqueue/launcher.py
@@ -60,7 +60,7 @@ def stop(cmd, env, staging_dir=None):
         if not os.path.exists(staging_dir):
             return
         try:
-            #shutil.rmtree(staging_dir)
+            shutil.rmtree(staging_dir)
             pass
         except Exception as exc:
             finish(

--- a/dask-gateway-server/dask_gateway_server/backends/jobqueue/lsf.py
+++ b/dask-gateway-server/dask_gateway_server/backends/jobqueue/lsf.py
@@ -4,7 +4,7 @@ import shutil
 import asyncio
 import json
 
-from traitlets import Unicode, Integer, default
+from traitlets import Unicode, Integer, List, default
 
 from .base import JobQueueBackend, JobQueueClusterConfig
 from ...traitlets import Type, Command

--- a/dask-gateway-server/dask_gateway_server/backends/jobqueue/lsf.py
+++ b/dask-gateway-server/dask_gateway_server/backends/jobqueue/lsf.py
@@ -129,9 +129,7 @@ class LSFBackend(JobQueueBackend):
             ]
         )
 
-        print(script)
         script = '\n'.join(script)
-        print(script)
         return cmd, env, script
 
     def get_stop_cmd_env(self, job_id):

--- a/dask-gateway-server/dask_gateway_server/backends/jobqueue/lsf.py
+++ b/dask-gateway-server/dask_gateway_server/backends/jobqueue/lsf.py
@@ -88,7 +88,7 @@ class LSFBackend(JobQueueBackend):
 
         script = ['#!/bin/sh']
 
-        script.append("#BSUB -J dask-gateway")
+        script.append("#BSUB -J dask-gateway-{}".format(cluster.name))
         if cluster.config.account:
             cmd.append("-P " + cluster.config.account)
         if cluster.config.alloc_flags:

--- a/dask-gateway-server/dask_gateway_server/backends/jobqueue/lsf.py
+++ b/dask-gateway-server/dask_gateway_server/backends/jobqueue/lsf.py
@@ -112,11 +112,13 @@ class LSFBackend(JobQueueBackend):
 
         script.append('#BSUB -o {}'.format(os.path.join(staging_dir, stdout_file)))
         script.append('#BSUB -e {}'.format(os.path.join(staging_dir, stderr_file)))
-        script.append('#BSUB -env all, %s' % (",".join(['{}={}'.format(var,env[var]) for var in sorted(env)]))),
+        script.append('')
+
+        for var in env:
+            script.append('export {}={}'.format(var,env[var]))
 
         cmd.append('-nnodes {}'.format(nodes))
 
-        script.append('')
         script.append('cd {}'.format(staging_dir))
 
         if worker:

--- a/dask-gateway-server/dask_gateway_server/backends/jobqueue/lsf.py
+++ b/dask-gateway-server/dask_gateway_server/backends/jobqueue/lsf.py
@@ -44,6 +44,7 @@ class LSFBackend(JobQueueBackend):
         kwargs["action"] = action
         proc = await asyncio.create_subprocess_exec(
             *cmd,
+            env=os.environ.copy(),
             stdin=asyncio.subprocess.PIPE,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,

--- a/dask-gateway-server/dask_gateway_server/backends/jobqueue/lsf.py
+++ b/dask-gateway-server/dask_gateway_server/backends/jobqueue/lsf.py
@@ -136,13 +136,14 @@ class LSFBackend(JobQueueBackend):
         return [self.cancel_command, job_id], {}
 
     def get_status_cmd_env(self, job_ids):
-        cmd = [self.status_command, "-o", "jobid stat", "-noheader"," %s" % " ".join(job_ids)]
+        cmd = [self.status_command, "-json", " %s" % " ".join(job_ids)]
         return cmd, {}
 
     def parse_job_states(self, stdout):
+        result = json.loads(stdout)
         states = {}
-        for l in stdout.splitlines():
-            job_id, state = l.split()
+        for record in result['RECORDS']:
+            job_id, state = record['JOBID'], record['STAT']
             states[job_id] = state in ("RUN", "PEND", "WAIT")
         return states
 


### PR DESCRIPTION
Implement an LSF scheduler backend. To make it work on the system of interest (Summit at ORNL), I had to make the scheduler and API ports configurable due to firewall restrictions.

resolves #333 

- [ ] update docs
- [ ] write unit tests