### PR TITLE
Add extension mechanism for side-loading config

### DIFF
--- a/resources/helm/dask-gateway/.helmignore
+++ b/resources/helm/dask-gateway/.helmignore
@@ -5,6 +5,7 @@
 # Common VCS dirs
 .git/
 .gitignore
+.gitkeep
 .bzr/
 .bzrignore
 .hg/

--- a/resources/helm/dask-gateway/extensions/README.rst
+++ b/resources/helm/dask-gateway/extensions/README.rst
@@ -1,0 +1,21 @@
+Extensions
+==========
+
+The extensions sub-directory is one of two mechanisms for injecting
+configuration into ``dask_gateway_config.py``. 
+
+The first method relies on ``extraConfig`` in ``values.yaml``. 
+
+To use this method, simply copy your extensions as either packages or modules
+into this directory or sub-directories within this directory. 
+
+Helm will copy the contents of any files that end in ``_config.py`` into
+``dask_gateway_config.py``. 
+
+The benefit of this approach is it lets you compartmentalize your Python code
+from your Helm YAML, which makes it possible to implement unit tests and
+continuous integration. 
+
+Please note, if your extensions rely on packages that are not installed by
+default in the upstream Dask Gateway API image, you will need to add those
+packages yourself.

--- a/resources/helm/dask-gateway/extensions/README.rst
+++ b/resources/helm/dask-gateway/extensions/README.rst
@@ -1,20 +1,62 @@
 Extensions
 ==========
 
-The extensions sub-directory is one of two mechanisms for injecting
-configuration into ``dask_gateway_config.py``. 
+The extensions directory is one of two mechanisms for injecting extensions into
+the Dask Gateway API.
 
-The first method relies on ``extraConfig`` in ``values.yaml``. 
+One approach is to inject your extensions through ``extraConfig`` in
+``values.yaml``.
 
-To use this method, simply copy your extensions as either packages or modules
-into this directory or sub-directories within this directory. 
+The other approach is to store your extensions as discrete Python modules in the
+``extensions`` directory.
 
-Helm will copy the contents of any files that end in ``_config.py`` into
-``dask_gateway_config.py``. 
+The extensions directory approach provides the following benefits:
 
-The benefit of this approach is it lets you compartmentalize your Python code
-from your Helm YAML, which makes it possible to implement unit tests and
-continuous integration. 
+- It disentangles your Python code from your Helm YAML. 
+- It allows you to implement unit tests and maintain continuous integration.
+
+That being said, the extensions directory approach assumes that you have cloned
+the upstream chart locally, which may not necessarily be the case. Different
+use-cases call for different solutions. 
+
+To leverage the extensions directory approach, copy your Python modules into
+``extensions/gateway`` and update ``extraConfig`` in ``values.yaml`` to import
+and implement them.
+
+For example, suppose you copy ``foo.py`` into ``extensions/gateway``.
+
+``foo.py`` contains a single function:
+
+.. code-block:: python
+
+    def bar():
+        print("bar")
+
+Simply update ``extraConfig`` in ``values.yaml`` to import your module:
+
+.. code-block:: YAML
+
+    from foo import bar
+
+You now have access to the ``bar`` function. 
+
+Practically speaking, your modules will most likely consist of subclasses that
+inherit from upstream base classes alongside configuration declarations that
+point to the subclasses.
+
+Please note, for a custom authenticator, you can use the ``custom``
+authentication type in ``values.yaml``:
+
+.. code-block:: python
+
+  auth:
+    type: custom custom:
+      class: <module>.<class>
+
+Under the hood, Helm globs the contents of ``extensions/gateway`` and adds them
+as key-value pairs to a ConfigMap. When the ConfigMap is mounted on the Dask
+Gateway API pods, all of the files are available in ``/etc/dask-gateway``, which
+is part of the Python path.
 
 Please note, if your extensions rely on packages that are not installed by
 default in the upstream Dask Gateway API image, you will need to add those

--- a/resources/helm/dask-gateway/templates/gateway/configmap.yaml
+++ b/resources/helm/dask-gateway/templates/gateway/configmap.yaml
@@ -18,6 +18,7 @@ data:
     {{- end }}
     import os
     import json
+    import sys
 
     _PROPERTIES = json.loads({{- $values | toJson | quote }})
 
@@ -107,6 +108,11 @@ data:
     else:
         raise ValueError("Unknown authenticator type %r" % auth_type)
 
+    # Add /etc/dask-gateway/ to the Python path.
+    # This is required for side-loaded extensions to work.
+    configuration_directory = os.path.dirname(os.path.realpath(__file__))
+    sys.path.insert(0, configuration_directory)
+
     {{- if $extraConfig }}
     {{ if kindIs "string" $extraConfig }}
     # From gateway.extraConfig
@@ -119,7 +125,7 @@ data:
     {{- end }}
     {{- end }}
 
-    {{/* Configuration pulled in through *_config.py files in the extensions directory */}}
-    {{ range $path, $_ :=  .Files.Glob  "**_config.py" }}
-        {{ $.Files.Get $path | nindent 4 }}
-    {{ end }}
+  {{- /* Glob files to be added to the ConfigMap. */ -}}
+  {{- /* These files are mounted alongside dask_gateway_config.py */ -}}
+  {{- /* key = filename; value = content of file */ -}}
+  {{- (.Files.Glob "extensions/gateway/*").AsConfig | nindent 2 }}

--- a/resources/helm/dask-gateway/templates/gateway/configmap.yaml
+++ b/resources/helm/dask-gateway/templates/gateway/configmap.yaml
@@ -118,3 +118,8 @@ data:
     {{- end }}
     {{- end }}
     {{- end }}
+
+    {{/* Configuration pulled in through *_config.py files in the extensions directory */}}
+    {{ range $path, $_ :=  .Files.Glob  "**_config.py" }}
+        {{ $.Files.Get $path | nindent 4 }}
+    {{ end }}

--- a/resources/helm/dask-gateway/templates/gateway/configmap.yaml
+++ b/resources/helm/dask-gateway/templates/gateway/configmap.yaml
@@ -6,9 +6,9 @@ metadata:
     {{- include "dask-gateway.labels" . | nindent 4 }}
 data:
   dask_gateway_config.py: |-
-    {{/* Extract extraConfig, as its handled separately */}}
+    {{- /* Extract extraConfig, as its handled separately */}}
     {{- $extraConfig := .Values.gateway.extraConfig }}
-    {{/* Remove secrets and extraConfig before forwarding configuration */}}
+    {{- /* Remove secrets and extraConfig before forwarding configuration */}}
     {{- $values := pick .Values "gateway" }}
     {{- $_ := set $values "gateway" (omit $values.gateway "extraConfig") }}
     {{- if $values.gateway.auth.jupyterhub.apiToken }}
@@ -19,6 +19,9 @@ data:
     import os
     import json
     import sys
+
+    # Add this directory to path to support extension modules
+    sys.path.insert(0, os.path.dirname(os.path.realpath(__file__)))
 
     _PROPERTIES = json.loads({{- $values | toJson | quote }})
 
@@ -108,11 +111,6 @@ data:
     else:
         raise ValueError("Unknown authenticator type %r" % auth_type)
 
-    # Add /etc/dask-gateway/ to the Python path.
-    # This is required for side-loaded extensions to work.
-    configuration_directory = os.path.dirname(os.path.realpath(__file__))
-    sys.path.insert(0, configuration_directory)
-
     {{- if $extraConfig }}
     {{ if kindIs "string" $extraConfig }}
     # From gateway.extraConfig
@@ -125,7 +123,8 @@ data:
     {{- end }}
     {{- end }}
 
-  {{- /* Glob files to be added to the ConfigMap. */ -}}
-  {{- /* These files are mounted alongside dask_gateway_config.py */ -}}
-  {{- /* key = filename; value = content of file */ -}}
-  {{- (.Files.Glob "extensions/gateway/*").AsConfig | nindent 2 }}
+  {{- /* Load any extension modules */ -}}
+  {{- $exts := .Files.Glob "extensions/gateway/*" }}
+  {{- if $exts }}
+    {{- $exts.AsConfig | nindent 2 }}
+  {{- end }}


### PR DESCRIPTION
This PR provides a mechanism for adding configuration / extensions without needing to install them through the Dockerfile (which requires managing your own image) or interleaving your Python code with Helm yamls via the `extraConfig` field in `values.yaml`. **This makes it possible to implement unit tests and continuous integration for extensions.**

To use this method, simply copy your extensions as either packages or modules
into the extensions directory or sub-directories within it.

Helm will copy the contents of any files that end in `_config.py` into
`dask_gateway_config.py`.

I have validated that this PR works with our auth and options extensions after appending the relevant files with `_config.py`.

Happy to submit a documentation PR as well if this gets approved.

This PR is fully backwards-compatible. It provides an alternative, not a replacement. 