### PR TITLE
Multiple workers per job

### DIFF
--- a/dask-gateway-server/dask_gateway_server/backends/base.py
+++ b/dask-gateway-server/dask_gateway_server/backends/base.py
@@ -6,6 +6,7 @@ from traitlets import (
     Integer,
     Float,
     Dict,
+    List,
     Union,
     Unicode,
     default,
@@ -368,6 +369,15 @@ class ClusterConfig(Configurable):
         min=0,
         config=True,
     )
+
+    extra_worker_cmdline_args = List(
+        help="""
+        List of extra command line arguments for the worker, in the format
+        ``['--argument1': 'value1', '--option2']``
+        """,
+        config=True,
+    )
+
 
     def _check_scheduler_memory(self, scheduler_memory, cluster_max_memory):
         if cluster_max_memory is not None and scheduler_memory > cluster_max_memory:

--- a/dask-gateway-server/dask_gateway_server/backends/db_base.py
+++ b/dask-gateway-server/dask_gateway_server/backends/db_base.py
@@ -1126,7 +1126,7 @@ class DBBackendBase(Backend):
                     if not ok
                 }
                 self.db.update_workers(updates)
-                for w, _ in updates:
+                for w in updates:
                     self.log.info("Worker %s failed during startup", w.name)
                     w.cluster.worker_start_failure_count += 1
                     self.queue.put(w)

--- a/dask-gateway/dask_gateway/client.py
+++ b/dask-gateway/dask_gateway/client.py
@@ -1165,7 +1165,8 @@ class GatewayCluster(object):
             return None
 
         try:
-            from ipywidgets import Layout, VBox, HBox, IntText, Button, HTML, Accordion
+            from ipywidgets import Layout, VBox, HBox, IntText, BoundedIntText,
+                                   Button, HTML, Accordion
         except ImportError:
             self._cached_widget = None
             return None

--- a/dask-gateway/dask_gateway/client.py
+++ b/dask-gateway/dask_gateway/client.py
@@ -1176,7 +1176,7 @@ class GatewayCluster(object):
 
         status = HTML(self._widget_status(), layout=Layout(min_width="150px"))
 
-        request = IntText(0, description="Workers", layout=layout)
+        request = BoundedIntText(0, min=0, description="Jobs", layout=layout)
         scale = Button(description="Scale", layout=layout)
 
         minimum = IntText(0, description="Minimum", layout=layout)

--- a/dask-gateway/dask_gateway/client.py
+++ b/dask-gateway/dask_gateway/client.py
@@ -1165,8 +1165,8 @@ class GatewayCluster(object):
             return None
 
         try:
-            from ipywidgets import Layout, VBox, HBox, IntText, BoundedIntText,
-                                   Button, HTML, Accordion
+            from ipywidgets import Layout, VBox, HBox, IntText
+            from ipywidgets import BoundedIntText, Button, HTML, Accordion
         except ImportError:
             self._cached_widget = None
             return None

--- a/dask-gateway/dask_gateway/scheduler_preload.py
+++ b/dask-gateway/dask_gateway/scheduler_preload.py
@@ -277,7 +277,8 @@ class GatewaySchedulerService(object):
             "closed_workers": list(self.closed_workers),
         }
 
-        await self.gateway.heartbeat(msg)
+        await self.gateway.heartbeat(msg,
+            request_timeout=self.heartbeat_period*2)
 
         if closing_workers:
             self.closing_workers.update(closing_workers)
@@ -369,7 +370,7 @@ class GatewayClient(object):
         self.token = api_token
         self.api_url = api_url
 
-    async def heartbeat(self, msg):
+    async def heartbeat(self, msg, request_timeout):
         client = AsyncHTTPClient()
         req = HTTPRequest(
             method="POST",
@@ -379,6 +380,8 @@ class GatewayClient(object):
                 "Content-type": "application/json",
             },
             body=json.dumps(msg),
+            request_timeout=request_timeout,
+            connect_timeout=request_timeout
         )
         await client.fetch(req)
 


### PR DESCRIPTION
This PR allows multiple worker instances to be assigned to a single job, extending the 1:1 mapping of jobs and workers to N:1. At the low-level, this is enabled by requiring the worker identifiers to have a common prefix and to end with a worker specific identifier after the dash, such as `-0`, `-1`, etc. This is supported through the standard `--nprocs` option in `dask-worker`, and through `dask-mpi` (https://github.com/dask/dask-mpi/pull/52).

A semantic change going along with this is that the `GatewayCluster` interface now allows requesting worker **jobs**, but displays the up-to-date number of **workers**.

[ ] Document
[ ] Unit tests