### PR TITLE
helm chart: Add label to be allowed direct network access to the jupyterhub pod

### DIFF
--- a/resources/helm/dask-gateway/templates/gateway/deployment.yaml
+++ b/resources/helm/dask-gateway/templates/gateway/deployment.yaml
@@ -15,6 +15,7 @@ spec:
       labels:
         {{- include "dask-gateway.labels" . | nindent 8 }}
         app.kubernetes.io/component: gateway
+        hub.jupyter.org/network-access-hub: "true"
       annotations:
         checksum/configmap: {{ include (print .Template.BasePath "/gateway/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print .Template.BasePath "/gateway/secret.yaml") . | sha256sum }}


### PR DESCRIPTION
This PR adds a label that grants the dask-gateway api-server access to speak with the `hub` pod in the JupyterHub Helm chart which is required if the JupyterHub Helm chart's network policy are enforced, as they are by default in the latest version. This is confirmed to resolve the issue identified in https://github.com/dask/helm-chart/issues/142.

The coupling that exists between the Helm charts come from configuring to use `jupyterhub` auth.