### PR TITLE
Add customizable worker_threads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,7 @@ jobs:
             - source continuous_integration/before_install.sh
           install:
             - source continuous_integration/install.sh
-            - pip install kubernetes_asyncio skein sphinx doctr dask-sphinx-theme sphinx-rtd-theme==0.4.3
+            - pip install kubernetes_asyncio skein sphinx==3.3.1 doctr dask-sphinx-theme sphinx-rtd-theme==0.4.3
           script:
             - |
               set -xe

--- a/dask-gateway-server/dask_gateway_server/backends/base.py
+++ b/dask-gateway-server/dask_gateway_server/backends/base.py
@@ -279,6 +279,16 @@ class ClusterConfig(Configurable):
         config=True,
     )
 
+    # Number of threads per worker. Defaults to the number of cores
+    worker_threads = Integer(
+        1,
+        min=1,
+        help="""
+        Number of threads available for a dask worker.
+        """,
+        config=True,
+    )
+
     scheduler_memory = MemoryLimit(
         "2 G",
         help="""

--- a/dask-gateway-server/dask_gateway_server/backends/base.py
+++ b/dask-gateway-server/dask_gateway_server/backends/base.py
@@ -281,13 +281,18 @@ class ClusterConfig(Configurable):
 
     # Number of threads per worker. Defaults to the number of cores
     worker_threads = Integer(
-        1,
         min=1,
         help="""
         Number of threads available for a dask worker.
+
+        Defaults to ``worker_cores``.
         """,
         config=True,
     )
+
+    @default("worker_threads")
+    def _default_worker_threads(self):
+        return self.worker_cores
 
     scheduler_memory = MemoryLimit(
         "2 G",

--- a/dask-gateway-server/dask_gateway_server/backends/db_base.py
+++ b/dask-gateway-server/dask_gateway_server/backends/db_base.py
@@ -1443,7 +1443,7 @@ class DBBackendBase(Backend):
         ]
 
     def worker_nthreads_memory_limit_args(self, cluster):
-        return str(cluster.config.worker_cores), str(cluster.config.worker_memory)
+        return str(cluster.config.worker_threads), str(cluster.config.worker_memory)
 
     def get_worker_command(self, cluster, worker_name, scheduler_address=None):
         nthreads, memory_limit = self.worker_nthreads_memory_limit_args(cluster)

--- a/dask-gateway-server/dask_gateway_server/backends/inprocess.py
+++ b/dask-gateway-server/dask_gateway_server/backends/inprocess.py
@@ -85,7 +85,7 @@ class InProcessBackend(UnsafeLocalBackend):
         workdir = worker.cluster.state["workdir"]
         self.workers[worker.name] = worker = Worker(
             worker.cluster.scheduler_address,
-            nthreads=worker.cluster.config.worker_cores,
+            nthreads=worker.cluster.config.worker_threads,
             memory_limit=0,
             security=security,
             name=worker.name,

--- a/dask-gateway-server/dask_gateway_server/backends/kubernetes/backend.py
+++ b/dask-gateway-server/dask_gateway_server/backends/kubernetes/backend.py
@@ -80,6 +80,10 @@ class KubeClusterConfig(ClusterConfig):
     def _default_worker_cores_limit(self):
         return self.worker_cores
 
+    @default("worker_threads")
+    def _default_worker_threads(self):
+        return int(self.worker_cores)
+
     worker_memory_limit = MemoryLimit(
         help="""
         Maximum number of bytes available for a dask worker. Allows the

--- a/dask-gateway-server/dask_gateway_server/backends/kubernetes/backend.py
+++ b/dask-gateway-server/dask_gateway_server/backends/kubernetes/backend.py
@@ -82,7 +82,7 @@ class KubeClusterConfig(ClusterConfig):
 
     @default("worker_threads")
     def _default_worker_threads(self):
-        return int(self.worker_cores)
+        return int(self.worker_cores_limit)
 
     worker_memory_limit = MemoryLimit(
         help="""

--- a/dask-gateway-server/dask_gateway_server/backends/kubernetes/controller.py
+++ b/dask-gateway-server/dask_gateway_server/backends/kubernetes/controller.py
@@ -1052,7 +1052,7 @@ class KubeController(KubeBackendAndControllerMixin, Application):
             "--name",
             "$(DASK_GATEWAY_WORKER_NAME)",
             "--nthreads",
-            str(int(config.worker_threads)),
+            str(config.worker_threads),
             "--memory-limit",
             str(config.worker_memory_limit),
         ]

--- a/dask-gateway-server/dask_gateway_server/backends/kubernetes/controller.py
+++ b/dask-gateway-server/dask_gateway_server/backends/kubernetes/controller.py
@@ -1052,7 +1052,7 @@ class KubeController(KubeBackendAndControllerMixin, Application):
             "--name",
             "$(DASK_GATEWAY_WORKER_NAME)",
             "--nthreads",
-            str(int(config.worker_cores_limit)),
+            str(int(config.worker_threads)),
             "--memory-limit",
             str(config.worker_memory_limit),
         ]

--- a/dask-gateway/dask_gateway/client.py
+++ b/dask-gateway/dask_gateway/client.py
@@ -744,6 +744,7 @@ _widget_status_template = """
 <table style="text-align: right;">
     <tr><th>Workers</th> <td>%d</td></tr>
     <tr><th>Cores</th> <td>%d</td></tr>
+    <tr><th>Threads</th> <td>%d</td></tr>
     <tr><th>Memory</th> <td>%s</td></tr>
 </table>
 </div>
@@ -1149,10 +1150,11 @@ class GatewayCluster(object):
             return None
         else:
             n_workers = len(workers)
-            cores = sum(w["nthreads"] for w in workers.values())
+            cores = sum(w["cores"] for w in workers.values())
+            threads = sum(w["nthreads"] for w in workers.values())
             memory = sum(w["memory_limit"] for w in workers.values())
 
-            return _widget_status_template % (n_workers, cores, format_bytes(memory))
+            return _widget_status_template % (n_workers, cores, threads, format_bytes(memory))
 
     def _widget(self):
         """ Create IPython widget for display within a notebook """

--- a/dask-gateway/dask_gateway/client.py
+++ b/dask-gateway/dask_gateway/client.py
@@ -743,7 +743,6 @@ _widget_status_template = """
 </style>
 <table style="text-align: right;">
     <tr><th>Workers</th> <td>%d</td></tr>
-    <tr><th>Cores</th> <td>%d</td></tr>
     <tr><th>Threads</th> <td>%d</td></tr>
     <tr><th>Memory</th> <td>%s</td></tr>
 </table>
@@ -1150,11 +1149,10 @@ class GatewayCluster(object):
             return None
         else:
             n_workers = len(workers)
-            cores = sum(w["cores"] for w in workers.values())
             threads = sum(w["nthreads"] for w in workers.values())
             memory = sum(w["memory_limit"] for w in workers.values())
 
-            return _widget_status_template % (n_workers, cores, threads, format_bytes(memory))
+            return _widget_status_template % (n_workers, threads, format_bytes(memory))
 
     def _widget(self):
         """ Create IPython widget for display within a notebook """


### PR DESCRIPTION
Hey

I added the possibility to customize the number of threads per worker.
Until now `worker_threads` = `cores` but that's not always the best combination.

If `worker_threads` is not set then it will fall-back to the default.

Let me know if you have any feedback

Fixes #364 
Fixes #362 