### PR TITLE
Make the traefik ingressroute and ingressroutetcp resources configurable

### DIFF
--- a/dask-gateway-server/dask_gateway_server/backends/kubernetes/controller.py
+++ b/dask-gateway-server/dask_gateway_server/backends/kubernetes/controller.py
@@ -347,13 +347,13 @@ class KubeController(KubeBackendAndControllerMixin, Application):
     make_ingressroute = Callable(
         _make_ingressroute,
         help="A callable function to override the default traefik ingressroute resource",
-        config=True
+        config=True,
     )
 
     make_ingressroutetcp = Callable(
         _make_ingressroutetcp,
         help="A callable function to override the default traefik ingressroutetcp resource",
-        config=True
+        config=True,
     )
 
     _log_formatter_cls = LogFormatter

--- a/tests/kubernetes/test_methods.py
+++ b/tests/kubernetes/test_methods.py
@@ -256,7 +256,7 @@ def test_make_ingressroute():
     cluster_name = "c1234"
     namespace = "mynamespace"
 
-    ingress = controller.make_ingressroute(cluster_name, namespace)
+    ingress = controller.make_ingressroute(controller, cluster_name, namespace)
 
     labels = ingress["metadata"]["labels"]
     assert labels["gateway.dask.org/instance"] == "instance-1234"
@@ -278,7 +278,7 @@ def test_make_ingressroutetcp():
     cluster_name = "c1234"
     namespace = "mynamespace"
 
-    ingress = controller.make_ingressroutetcp(cluster_name, namespace)
+    ingress = controller.make_ingressroutetcp(controller, cluster_name, namespace)
 
     labels = ingress["metadata"]["labels"]
     assert labels["gateway.dask.org/instance"] == "instance-1234"


### PR DESCRIPTION
With QHub we have the goal of deploying kubernetes on multiple clouds and locally which makes depending on the load balancer for encryption difficult. We needed to annotate (somehow) the ingressroute resource to add tls via the following snippet. More details are in the [issue](https://github.com/dask/dask-gateway/issues/389). Here I've tried to make this as uncontroversial as possible by just adding two Callables for the `make_ingressroute` and `make_ingressroutetcp`.

```yaml
tls:
  certResolver: default
```

Currently with dask-gateway it is not possible to override the traefik ingressroute and ingresstls resource being generated on the fly by the KubeController.

Closes https://github.com/dask/dask-gateway/issues/389