### PR TITLE
added a missing comma in the profile options code chunk example

### DIFF
--- a/docs/source/cluster-options.rst
+++ b/docs/source/cluster-options.rst
@@ -168,7 +168,7 @@ from.
             ["small", "medium", "large"],
             default="medium",
             label="Cluster Profile",
-        )
+        ),
         handler=lambda options: profiles[options.profile],
     )
 


### PR DESCRIPTION
This fixes an example code chunk for exposing cluster options as profiles. The missing comma caused a syntax error on deployment.