### PR TITLE
Move CI to GitHub Actions

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,49 @@
+name: Docs
+
+on:
+  push:
+    # TODO: Only main
+    branches: [ "*" ]
+
+env:
+  commit_msg: ${{ github.event.head_commit.message }}
+
+jobs:
+  main-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.14'
+
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '6'
+      - name: Install requirements
+        run: |
+          go get github.com/stretchr/testify/assert
+          source continuous_integration/install.sh
+
+      - name: Install
+        run: |
+          source continuous_integration/install.sh
+          pip install kubernetes_asyncio skein sphinx==3.3.1 doctr dask-sphinx-theme sphinx-rtd-theme==0.4.3
+      - name: Build docs
+        run: |
+          pushd docs
+          make html
+
+      - name: Deploy to GitHub Pages
+        uses: JamesIves/github-pages-deploy-action@4.1.4
+        with:
+          branch: gh-pages
+          folder: docs/build/html/

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,8 +26,7 @@ jobs:
 
       - name: Setup Node
         uses: actions/setup-node@v2
-        with:
-          node-version: '6'
+
       - name: Install requirements
         run: |
           go get github.com/stretchr/testify/assert

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Run Tests
         run: |
-          py.test tests/ -v
+          py.test tests/ -k 'not kubernetes' -v
 
       - name: Flake8 and Black
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,6 +32,10 @@ jobs:
           go get github.com/stretchr/testify/assert
           source continuous_integration/install.sh
 
+      - name: List Packages
+        run: |
+          pip freeze
+
       - name: Run Tests
         run: |
           py.test tests/ -v

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,123 @@
+name: Test
+
+on:
+  push:
+    # TODO: Only main
+    branches: [ "*" ]
+
+env:
+  commit_msg: ${{ github.event.head_commit.message }}
+
+jobs:
+  main-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.14'
+
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: '6'
+      - name: Install requirements
+        run: |
+          go get github.com/stretchr/testify/assert
+          source continuous_integration/install.sh
+
+      - name: Run Tests
+        run: |
+          py.test tests/ -v
+
+      - name: Flake8 and Black
+        run: |
+          flake8
+          black . --check
+
+      - name: Go Tests
+        run: |
+          pushd dask-gateway-server/dask-gateway-proxy
+          go test
+          popd
+
+  hadoop-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Hadoop Install/Start
+        if: ${{ env.commit_msg != 'skip-tests' }}
+        run: |
+          ./continuous_integration/docker/hadoop/start.sh
+          ./continuous_integration/docker/hadoop/install.sh
+          ./continuous_integration/docker/hadoop/script.sh
+
+  kubernetes-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: AbsaOSS/k3d-action@v1.5.0
+        name: "Create k3d Cluster"
+        with:
+          cluster-name: "k3s-default"
+          args: >-
+            -p "30200:30200@agent[0]"
+            --agents 1
+            --api-port 6444
+            --no-lb
+
+      - name: Install tools
+        run: |
+          export KUBECONFIG="$(k3d get-kubeconfig --name='k3s-default')"
+          ./continuous_integration/kubernetes/install-tools.sh
+
+      - name: Check k3d
+        run: |
+          k3d --version
+          kubectl get nodes
+
+      - name: Helm Install
+        run: |
+          stern "" > k8s-logs &
+          echo "STERN_PID=$!" >> $GITHUB_ENV
+          ./continuous_integration/kubernetes/helm-install.sh
+          ./continuous_integration/kubernetes/install.sh
+
+      - name: Kubernetes Tests
+        run: |
+          ./continuous_integration/kubernetes/script.sh
+
+      - name: Kubernetes log
+        if: ${{ always() }}
+        run: |
+          kill ${{ env.STERN_PID }}
+          cat k8s-logs
+
+  pbs-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: PBS Tests
+        if: ${{ env.commit_msg != 'skip-tests' }}
+        run: |
+          ./continuous_integration/docker/pbs/start.sh
+          ./continuous_integration/docker/pbs/install.sh
+          ./continuous_integration/docker/pbs/script.sh
+
+  slurm-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Slurm Tests
+        if: ${{ env.commit_msg != 'skip-tests' }}
+        run: |
+          ./continuous_integration/docker/slurm/start.sh
+          ./continuous_integration/docker/slurm/install.sh
+          ./continuous_integration/docker/slurm/script.sh

--- a/continuous_integration/docker/hadoop/_install.sh
+++ b/continuous_integration/docker/hadoop/_install.sh
@@ -6,6 +6,7 @@ set -xe
 cd /working
 
 conda install psutil pykerberos
+conda install -c conda-forge python=3.8
 
 pip install \
     aiohttp \

--- a/continuous_integration/docker/pbs/_install.sh
+++ b/continuous_integration/docker/pbs/_install.sh
@@ -6,6 +6,7 @@ set -xe
 cd /working
 
 conda install psutil
+conda install -c conda-forge python=3.8
 
 pip install \
     aiohttp \

--- a/continuous_integration/docker/slurm/_install.sh
+++ b/continuous_integration/docker/slurm/_install.sh
@@ -6,6 +6,7 @@ set -xe
 cd /working
 
 conda install psutil
+conda install -c conda-forge python=3.8
 
 pip install \
     aiohttp \

--- a/continuous_integration/kubernetes/helm-install.sh
+++ b/continuous_integration/kubernetes/helm-install.sh
@@ -17,7 +17,7 @@ export DASK_GATEWAY_SERVER_IMAGE="daskgateway/dask-gateway-server:$DASK_GATEWAY_
 docker tag $DASK_GATEWAY_SERVER_TAG $DASK_GATEWAY_SERVER_IMAGE
 
 echo "Importing images into k3d"
-k3d import-images $DASK_GATEWAY_IMAGE $DASK_GATEWAY_SERVER_IMAGE
+k3d image import $DASK_GATEWAY_IMAGE $DASK_GATEWAY_SERVER_IMAGE
 
 echo "Installing Helm Chart"
 helm install \

--- a/continuous_integration/kubernetes/install-tools.sh
+++ b/continuous_integration/kubernetes/install-tools.sh
@@ -3,7 +3,6 @@ set -e
 
 KUBE_VERSION=1.16.0
 HELM_VERSION=3.1.2
-K3D_VERSION=1.6.0
 STERN_VERSION=1.11.0
 
 # Install kubectl
@@ -18,12 +17,6 @@ curl -sSLo "helm.tar.gz" "https://get.helm.sh/helm-v${HELM_VERSION}-linux-amd64.
     && tar -xf "helm.tar.gz" --strip-components 1 linux-amd64/helm \
     && rm "helm.tar.gz" \
     && sudo mv helm /usr/local/bin/
-
-# Install k3d
-echo "Installing k3d"
-curl -Lo k3d https://github.com/rancher/k3d/releases/download/v${K3D_VERSION}/k3d-linux-amd64 \
-    && chmod +x k3d \
-    && sudo mv k3d /usr/local/bin/
 
 # Install stern
 echo "Installing stern"

--- a/tests/kubernetes/test_helm.py
+++ b/tests/kubernetes/test_helm.py
@@ -5,6 +5,8 @@ import yaml
 
 import pytest
 
+pytestmark = pytest.mark.kubernetes
+
 try:
     subprocess.check_call(["helm", "version"])
 except Exception:


### PR DESCRIPTION
Fixes #346 

First pass at converting from `.travis.yml` to GitHub Actions.

Notes:
- This doesn't includes skipping tests based on commit message at the moment, not sure if we need them (thoughts?)
- Currently runs on all branches (will change before merge)
- The tests are failing (probably because they are failing in Travis as well)
- Fixing flaky tests is beyond the scope of this, we can fix them, after this is merged (?).
- Also, it seems most of the tests haven't ran for a [long long time](https://travis-ci.org/github/dask/dask-gateway/builds) except the main tests.

Here are the sample runs:
Docs: https://github.com/aktech/dask-gateway/actions/runs/1024666853
Tests: https://github.com/aktech/dask-gateway/actions/runs/1024666852

@jacobtomlinson @martindurant 