### PR TITLE
Add support for authenticating with JupyterHub service

### DIFF
--- a/dask-gateway-server/dask_gateway_server/auth.py
+++ b/dask-gateway-server/dask_gateway_server/auth.py
@@ -391,7 +391,7 @@ class JupyterHubAuthenticator(Authenticator):
         if resp.status < 400:
             data = await resp.json()
             # "groups" attribute doesn't exists in case of a service
-            return User(data["name"], groups=data.get("groups", []), admin=data["admin"])
+            return User(data["name"], groups=data.get("groups", []), admin=data.get("admin", False))
         elif resp.status == 404:
             self.log.debug("Token for non-existent user requested")
             raise unauthorized("jupyterhub")

--- a/dask-gateway-server/dask_gateway_server/auth.py
+++ b/dask-gateway-server/dask_gateway_server/auth.py
@@ -390,9 +390,10 @@ class JupyterHubAuthenticator(Authenticator):
 
         if resp.status < 400:
             data = await resp.json()
-            return User(data["name"], groups=data["groups"], admin=data["admin"])
+            # "groups" attribute doesn't exists in case of a service
+            return User(data["name"], groups=data.get("groups", []), admin=data["admin"])
         elif resp.status == 404:
-            self.log.debug("Token for non-existant user requested")
+            self.log.debug("Token for non-existent user requested")
             raise unauthorized("jupyterhub")
         else:
             if resp.status == 403:


### PR DESCRIPTION
Fixes #409 

We can also create a separate object for Service, but I am not sure, what we'll gain from it apart from being a bit more explicit about differentiating between `User` and `Service`. Open to suggestions here.

cc @martindurant 