### PR TITLE
Fix travis main tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ python:
 git:
   depth: false  # Ensure latest tag is pulled
 
-branches:
-  only:
-    - main
-
 jobs:
     fast_finish: true
 

--- a/continuous_integration/before_install.sh
+++ b/continuous_integration/before_install.sh
@@ -1,5 +1,4 @@
 gimme 1.14 \
 && source ~/.gimme/envs/go1.14.env \
 && go get github.com/stretchr/testify/assert \
-&& nvm install 6 \
-&& nvm use 6
+&& nvm install node

--- a/dask-gateway-server/dask_gateway_server/auth.py
+++ b/dask-gateway-server/dask_gateway_server/auth.py
@@ -391,7 +391,11 @@ class JupyterHubAuthenticator(Authenticator):
         if resp.status < 400:
             data = await resp.json()
             # "groups" attribute doesn't exists in case of a service
-            return User(data["name"], groups=data.get("groups", []), admin=data.get("admin", False))
+            return User(
+                data["name"],
+                groups=data.get("groups", []),
+                admin=data.get("admin", False),
+            )
         elif resp.status == 404:
             self.log.debug("Token for non-existent user requested")
             raise unauthorized("jupyterhub")

--- a/dask-gateway/dask_gateway/client.py
+++ b/dask-gateway/dask_gateway/client.py
@@ -1155,7 +1155,7 @@ class GatewayCluster(object):
             return _widget_status_template % (n_workers, threads, format_bytes(memory))
 
     def _widget(self):
-        """ Create IPython widget for display within a notebook """
+        """Create IPython widget for display within a notebook"""
         try:
             return self._cached_widget
         except AttributeError:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -177,7 +177,7 @@ async def test_jupyterhub_auth_service(monkeypatch):
     hub_config = Config()
     hub_config.JupyterHub.services = [
         {"name": "dask-gateway", "api_token": jhub_api_token},
-        {"name": "any-service", "api_token": jhub_service_token}
+        {"name": "any-service", "api_token": jhub_service_token},
     ]
     hub_config.JupyterHub.bind_url = jhub_bind_url
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -253,6 +253,7 @@ async def test_client_reprs():
             # HTML repr with no dashboard
             cluster.dashboard_link = None
             assert "Not Available" in cluster._repr_html_()
+            await cluster.shutdown()
 
 
 @pytest.mark.asyncio

--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -64,6 +64,8 @@ async def cluster_and_security(tmpdir):
         tls_scheduler_cert=tls_cert_path,
         tls_client_key=tls_key_path,
         tls_client_cert=tls_cert_path,
+        tls_worker_key=tls_key_path,
+        tls_worker_cert=tls_cert_path,
         tls_ca_file=tls_cert_path,
         require_encryption=True,
     )


### PR DESCRIPTION
This fixes the broken travis tests (for env MAIN-TEST=true). This a step towards getting #408 merged.

- [x] Add worker certs config for `cluster_and_security` fixture
- [x] Install latest node to fix jupyterhub tests (unable to start proxy server without it)
- [x] shutdown cluster in the `test_client_reprs` test causing domino effect on the following tests and making them flaky
- [x] Make black happy
- [x] Run travis on all branches

✅ Passing tests can be seen here: https://www.travis-ci.com/github/aktech/dask-gateway/builds/233513175

@TomAugspurger @martindurant @jacobtomlinson @douglasdavis 