### PR TITLE
Fix Kubernetes CI Tests

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -2,7 +2,7 @@ name: Docs
 
 on:
   push:
-    branches: [ "*" ]
+    branches: [ "main" ]
 
 env:
   commit_msg: ${{ github.event.head_commit.message }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -2,14 +2,13 @@ name: Docs
 
 on:
   push:
-    # TODO: Only main
     branches: [ "*" ]
 
 env:
   commit_msg: ${{ github.event.head_commit.message }}
 
 jobs:
-  main-tests:
+  docs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,6 +3,9 @@ name: Test
 on:
   push:
     branches: [ "*" ]
+  pull_request:
+    branches:
+      - main
 
 env:
   commit_msg: ${{ github.event.head_commit.message }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,6 @@ name: Test
 
 on:
   push:
-    # TODO: Only main
     branches: [ "*" ]
 
 env:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -101,9 +101,6 @@ jobs:
         run: |
           kill ${{ env.STERN_PID }}
           cat k8s-logs
-      - name: To enter a SSH debugging session, read these logs
-        if: failure()
-        uses: mxschmitt/action-tmate@v3
 
   pbs-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -75,7 +75,6 @@ jobs:
             --agents 1
             --api-port 6444
             --no-lb
-
       - name: Install tools
         run: |
           export KUBECONFIG="$(k3d get-kubeconfig --name='k3s-default')"
@@ -102,6 +101,9 @@ jobs:
         run: |
           kill ${{ env.STERN_PID }}
           cat k8s-logs
+      - name: To enter a SSH debugging session, read these logs
+        if: failure()
+        uses: mxschmitt/action-tmate@v3
 
   pbs-tests:
     runs-on: ubuntu-latest

--- a/continuous_integration/kubernetes/helm-install.sh
+++ b/continuous_integration/kubernetes/helm-install.sh
@@ -17,7 +17,10 @@ export DASK_GATEWAY_SERVER_IMAGE="daskgateway/dask-gateway-server:$DASK_GATEWAY_
 docker tag $DASK_GATEWAY_SERVER_TAG $DASK_GATEWAY_SERVER_IMAGE
 
 echo "Importing images into k3d"
+echo "DASK_GATEWAY_IMAGE: $DASK_GATEWAY_IMAGE"
+echo "DASK_GATEWAY_SERVER_IMAGE: $DASK_GATEWAY_SERVER_IMAGE"
 k3d image import $DASK_GATEWAY_IMAGE $DASK_GATEWAY_SERVER_IMAGE
+k3d image import $DASK_GATEWAY_SERVER_IMAGE
 
 echo "Installing Helm Chart"
 helm install \

--- a/continuous_integration/kubernetes/install.sh
+++ b/continuous_integration/kubernetes/install.sh
@@ -16,11 +16,11 @@ pip install -U \
     traitlets
 
 pushd dask-gateway
-python setup.py develop
+sudo python setup.py develop
 popd
 
 pushd dask-gateway-server
-python setup.py develop --no-build-proxy
+sudo python setup.py develop --no-build-proxy
 popd
 
 pip list

--- a/dask-gateway/Dockerfile
+++ b/dask-gateway/Dockerfile
@@ -46,8 +46,8 @@ ENTRYPOINT ["tini", "-g", "--"]
 # ** An image with all of dask-gateway's dependencies **
 FROM miniconda as dependencies
 
-ARG DASK_VERSION=2.30.0
-ARG DISTRIBUTED_VERSION=2.30.1
+ARG DASK_VERSION=2021.7.1
+ARG DISTRIBUTED_VERSION=2021.7.1
 
 # - Installs dask and dependencies
 # - Cleans up conda files

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -5,7 +5,7 @@ import dask_gateway_server
 
 # Project settings
 project = "Dask Gateway"
-copyright = "2019, Jim Crist-Harif"
+copyright = "2021, Jim Crist-Harif"
 author = "Jim Crist-Harif"
 release = version = dask_gateway_server.__version__
 

--- a/resources/helm/dask-gateway/templates/gateway/configmap.yaml
+++ b/resources/helm/dask-gateway/templates/gateway/configmap.yaml
@@ -66,6 +66,7 @@ data:
         ("worker_cores_limit", "worker.cores.limit"),
         ("worker_memory", "worker.memory.request"),
         ("worker_memory_limit", "worker.memory.limit"),
+        ("worker_threads", "worker.threads"),
         ("worker_extra_container_config", "worker.extraContainerConfig"),
         ("worker_extra_pod_config", "worker.extraPodConfig"),
         # Additional fields

--- a/resources/helm/dask-gateway/values.yaml
+++ b/resources/helm/dask-gateway/values.yaml
@@ -126,6 +126,9 @@ gateway:
         request: null
         limit: null
 
+      # Number of threads available for a worker
+      threads: 1
+
   # Settings for nodeSelector, affinity, and tolerations for the gateway pods
   nodeSelector: {}
   affinity: {}


### PR DESCRIPTION
Fixes #412 

- [x] Fixes the image import to k3d, which was causing tests to not run.
- [x] Fix installation in k8s step
- [x] Update dask and distributed versions to remove version mismatch to avoid TLS handshake issues in the tests
- [x] Adds worker threads to KubeClusterConfig to [avoid KeyError: 'worker_threads' ](https://github.com/aktech/dask-gateway/runs/3171167471?check_suite_focus=true)
- [x] Misc - remove todos, copyright

cc @martindurant 