### PR TITLE
Use format_bytes from dask instead of distributed

### DIFF
--- a/dask-gateway/dask_gateway/client.py
+++ b/dask-gateway/dask_gateway/client.py
@@ -15,10 +15,11 @@ from urllib.parse import urlparse
 import aiohttp
 import dask
 import yarl
+from dask.utils import format_bytes
 from distributed import Client
 from distributed.core import rpc
 from distributed.security import Security
-from distributed.utils import LoopRunner, format_bytes
+from distributed.utils import LoopRunner
 
 # Register gateway protocol
 from . import comm


### PR DESCRIPTION
https://github.com/dask/distributed/pull/4966 deprecated
`distributed.utils.format_bytes`. We should use the version from
`dask.utils`. I didn't check the exact version of Dask it was added, but
it was >2 years ago, so I think we're OK.