### PR TITLE
helm chart: don't package a README.rst file

### DIFF
--- a/resources/helm/dask-gateway/.helmignore
+++ b/resources/helm/dask-gateway/.helmignore
@@ -21,3 +21,7 @@
 .idea/
 *.tmproj
 .vscode/
+
+# Manually added entries
+*.rst
+.gitkeep


### PR DESCRIPTION
Whatever is in a Helm chart's folder is packaged unless its listed in .helmignore. This means that the Helm chart will ship with files in its .tgz format and when installed will be available and embedded in k8s Secrets - one copy in each revision of the Helm chart.

No point of including a README.rst file there.