### PR TITLE
helm chart: refactor to use consistent modern syntax

### DIFF
--- a/resources/helm/dask-gateway/templates/controller/deployment.yaml
+++ b/resources/helm/dask-gateway/templates/controller/deployment.yaml
@@ -20,8 +20,8 @@ spec:
         app.kubernetes.io/component: controller
       annotations:
         checksum/configmap: {{ include (print .Template.BasePath "/controller/configmap.yaml") . | sha256sum }}
-        {{- if .Values.controller.annotations }}
-        {{- .Values.controller.annotations | toYaml | trimSuffix "\n" | nindent 8 }}
+        {{- with .Values.controller.annotations }}
+        {{- . | toYaml | nindent 8 }}
         {{- end }}
     spec:
       {{- if .Values.rbac.enabled }}
@@ -37,7 +37,7 @@ spec:
             name: {{ include "dask-gateway.controllerName" . }}
       {{- with .Values.controller.imagePullSecrets }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
+        {{- . | toYaml | nindent 8 }}
       {{- end }}
       containers:
         - name: controller
@@ -48,8 +48,10 @@ spec:
             - kube-controller
             - --config
             - /etc/dask-gateway/dask_gateway_config.py
+          {{- with .Values.controller.resources }}
           resources:
-            {{- .Values.controller.resources | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - mountPath: /etc/dask-gateway/
               name: configmap
@@ -58,14 +60,14 @@ spec:
               name: api
       {{- with .Values.controller.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+        {{- . | toYaml | nindent 8 }}
       {{- end }}
       {{- with .Values.controller.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
+        {{- . | toYaml | nindent 8 }}
       {{- end }}
       {{- with .Values.controller.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
+        {{- . | toYaml | nindent 8 }}
       {{- end }}
 {{- end }}

--- a/resources/helm/dask-gateway/templates/controller/rbac.yaml
+++ b/resources/helm/dask-gateway/templates/controller/rbac.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.controller.enabled -}}
 {{- if .Values.rbac.enabled -}}
-{{- if not .Values.rbac.controller.serviceAccountName }}
+{{- if not .Values.rbac.controller.serviceAccountName -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/resources/helm/dask-gateway/templates/gateway/deployment.yaml
+++ b/resources/helm/dask-gateway/templates/gateway/deployment.yaml
@@ -19,8 +19,8 @@ spec:
       annotations:
         checksum/configmap: {{ include (print .Template.BasePath "/gateway/configmap.yaml") . | sha256sum }}
         checksum/secret: {{ include (print .Template.BasePath "/gateway/secret.yaml") . | sha256sum }}
-        {{- if .Values.gateway.annotations }}
-        {{- .Values.gateway.annotations | toYaml | trimSuffix "\n" | nindent 8 }}
+        {{- with .Values.gateway.annotations }}
+        {{- . | toYaml | nindent 8 }}
         {{- end }}
     spec:
       {{- if .Values.rbac.enabled }}
@@ -36,7 +36,7 @@ spec:
             name: {{ include "dask-gateway.apiName" . }}
       {{- with .Values.gateway.imagePullSecrets }}
       imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
+        {{- . | toYaml | nindent 8 }}
       {{- end }}
       containers:
         - name: gateway
@@ -46,8 +46,10 @@ spec:
             - dask-gateway-server
             - --config
             - /etc/dask-gateway/dask_gateway_config.py
+          {{- with .Values.gateway.resources }}
           resources:
-            {{- .Values.gateway.resources | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
+          {{- end }}
           volumeMounts:
             - mountPath: /etc/dask-gateway/
               name: configmap
@@ -86,13 +88,13 @@ spec:
           {{- end }}
       {{- with .Values.gateway.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+        {{- . | toYaml | nindent 8 }}
       {{- end }}
       {{- with .Values.gateway.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
+        {{- . | toYaml | nindent 8 }}
       {{- end }}
       {{- with .Values.gateway.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
+        {{- . | toYaml | nindent 8 }}
       {{- end }}

--- a/resources/helm/dask-gateway/templates/gateway/rbac.yaml
+++ b/resources/helm/dask-gateway/templates/gateway/rbac.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.enabled -}}
-{{- if not .Values.rbac.gateway.serviceAccountName }}
+{{- if not .Values.rbac.gateway.serviceAccountName -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/resources/helm/dask-gateway/templates/gateway/secret.yaml
+++ b/resources/helm/dask-gateway/templates/gateway/secret.yaml
@@ -1,4 +1,4 @@
-{{- if (eq .Values.gateway.auth.type "jupyterhub") }}
+{{- if eq .Values.gateway.auth.type "jupyterhub" -}}
 kind: Secret
 apiVersion: v1
 metadata:
@@ -7,5 +7,5 @@ metadata:
     {{- include "dask-gateway.labels" . | nindent 4 }}
 type: Opaque
 data:
-  jupyterhub-api-token: {{ (required "gateway.auth.jupyterhub.apiToken must be defined when using jupyterhub auth" .Values.gateway.auth.jupyterhub.apiToken) | b64enc | quote }}
+  jupyterhub-api-token: {{ required "gateway.auth.jupyterhub.apiToken must be defined when using jupyterhub auth" .Values.gateway.auth.jupyterhub.apiToken | b64enc | quote }}
 {{- end }}

--- a/resources/helm/dask-gateway/templates/gateway/service.yaml
+++ b/resources/helm/dask-gateway/templates/gateway/service.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "dask-gateway.labels" . | nindent 4 }}
   {{- with .Values.gateway.service.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- . | toYaml | nindent 4 }}
   {{- end }}
 spec:
   type: ClusterIP

--- a/resources/helm/dask-gateway/templates/traefik/dashboard.yaml
+++ b/resources/helm/dask-gateway/templates/traefik/dashboard.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.traefik.dashboard }}
+{{- if .Values.traefik.dashboard -}}
 apiVersion: traefik.containo.us/v1alpha1
 kind: IngressRoute
 metadata:
@@ -14,4 +14,4 @@ spec:
     services:
     - name: api@internal
       kind: TraefikService
-{{- end -}}
+{{- end }}

--- a/resources/helm/dask-gateway/templates/traefik/deployment.yaml
+++ b/resources/helm/dask-gateway/templates/traefik/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "dask-gateway.labels" . | nindent 4 }}
 spec:
-  replicas: {{ default 1 .Values.traefik.replicas }}
+  replicas: {{ .Values.traefik.replicas }}
   selector:
     matchLabels:
       {{- include "dask-gateway.matchLabels" . | nindent 6 }}
@@ -17,7 +17,7 @@ spec:
         app.kubernetes.io/component: traefik
       {{- with .Values.traefik.annotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
+        {{- . | toYaml | nindent 8 }}
       {{- end }}
     spec:
       {{- if .Values.rbac.enabled }}
@@ -34,8 +34,10 @@ spec:
           securityContext:
             runAsUser: 1000
             runAsGroup: 1000
+          {{- with .Values.traefik.resources }}
           resources:
-            {{- .Values.traefik.resources | toYaml | trimSuffix "\n" | nindent 12 }}
+            {{- . | toYaml | nindent 12 }}
+          {{- end }}
           args:
             - "--global.checknewversion=False"
             - "--global.sendanonymoususage=False"
@@ -85,13 +87,13 @@ spec:
             timeoutSeconds: 2
       {{- with .Values.traefik.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+        {{- . | toYaml | nindent 8 }}
       {{- end }}
       {{- with .Values.traefik.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
+        {{- . | toYaml | nindent 8 }}
       {{- end }}
       {{- with .Values.traefik.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
+        {{- . | toYaml | nindent 8 }}
       {{- end }}

--- a/resources/helm/dask-gateway/templates/traefik/rbac.yaml
+++ b/resources/helm/dask-gateway/templates/traefik/rbac.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.rbac.enabled -}}
-{{- if not .Values.rbac.traefik.serviceAccountName }}
+{{- if not .Values.rbac.traefik.serviceAccountName -}}
 kind: ServiceAccount
 apiVersion: v1
 metadata:

--- a/resources/helm/dask-gateway/templates/traefik/service.yaml
+++ b/resources/helm/dask-gateway/templates/traefik/service.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "dask-gateway.labels" . | nindent 4 }}
   {{- with .Values.traefik.service.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- . | toYaml | nindent 4 }}
   {{- end }}
 spec:
   type: {{ .Values.traefik.service.type }}
@@ -14,21 +14,21 @@ spec:
     {{- include "dask-gateway.matchLabels" . | nindent 4 }}
     app.kubernetes.io/component: traefik
   {{- with .Values.traefik.service.spec }}
-  {{- toYaml . | nindent 2 }}
+  {{- . | toYaml | nindent 2 }}
   {{- end }}
   ports:
     - name: web
       targetPort: 8000
       port: {{ .Values.traefik.service.ports.web.port }}
-      {{- if .Values.traefik.service.ports.web.nodePort }}
-      nodePort: {{ .Values.traefik.service.ports.web.nodePort }}
+      {{- with .Values.traefik.service.ports.web.nodePort }}
+      nodePort: {{ . }}
       {{- end }}
     {{- if ne (toString .Values.traefik.service.ports.tcp.port) "web" }}
     - name: tcp
       targetPort: 8786
       port: {{ .Values.traefik.service.ports.tcp.port }}
-      {{- if .Values.traefik.service.ports.tcp.nodePort }}
-      nodePort: {{ .Values.traefik.service.ports.tcp.nodePort }}
+      {{- with .Values.traefik.service.ports.tcp.nodePort }}
+      nodePort: {{ . }}
       {{- end }}
     {{- end }}
     {{- if .Values.traefik.dashboard }}


### PR DESCRIPTION
I recognize a lot of practices from the JupyterHub Helm chart made it into this Helm chart. In this PR make the templates consistent in its syntax across helm template files and align with the best practices that have now also to some degree made its way all to Helms official documentation.

This PR should have no influence on anything in practice.

About the various kinds of changes made:
- `trimSuffix "\n"` is no longer needed with modern versions of `helm` and would be harmless to remove anyhow
- A replica count had a `default 1` that served no purpose
- Sometimes it was `. | toYaml | nindent 4`, othertimes it was `toYaml . | nindent 4`. I made it consistently like the former example.
- Some whitespace chomping practices enforced:
  - always chomp right on the first line in a template file
  - almost always chomp left but not to the right elsewhere
- if statements became with statements where possible to avoid duplicating a reference to some variable (with statements also function as as if statements).
- redundant parenthesis removed