### PR TITLE
ci: add --color=yes to pytest as needed in github actions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,9 @@
 [tool.black]
 line-length = 88
 target-version = ['py35', 'py36', 'py37']
+
+[tool.pytest.ini_options]
+# GitHub Actions make it hard for pytest to conlcude it should use colors, due
+# to this we explicitly make it do so. This is related to:
+# https://github.com/actions/runner/issues/241
+addopts = '--color=yes'


### PR DESCRIPTION
GitHub actions doesn't make pytest realize it can emit colors as for example TravisCI did. It is a long standing issue open about this someplace I remember.