### PR TITLE
Register a kubernetes pytest mark

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,3 +8,10 @@ def reset_logs():
     # PDB's stdout/stderr capture can close fds that our loggers are configured
     # to write to. To prevent this, reset the log handlers before every test.
     logging.getLogger("DaskGateway").handlers.clear()
+
+
+def pytest_configure(config):
+    # Adds a marker here, rather than setup.cfg, since the repository has two packages.
+    config.addinivalue_line(
+        "markers", "kubernetes: marks a test as kubernetes-related"
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,4 @@ def reset_logs():
 
 def pytest_configure(config):
     # Adds a marker here, rather than setup.cfg, since the repository has two packages.
-    config.addinivalue_line(
-        "markers", "kubernetes: marks a test as kubernetes-related"
-    )
+    config.addinivalue_line("markers", "kubernetes: marks a test as kubernetes-related")


### PR DESCRIPTION
This fixes the warning from pytest about an unknown mark

```
tests/kubernetes/test_helm.py:8
  /home/taugspurger/src/dask/dask-gateway/tests/kubernetes/test_helm.py:8: PytestUnknownMarkWarning: Unknown pytest.mark.kubernetes - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/mark.html
    pytestmark = pytest.mark.kubernetes
```