### PR TITLE
Avoid warning in Gateway.__del__

### DIFF
--- a/dask-gateway/dask_gateway/client.py
+++ b/dask-gateway/dask_gateway/client.py
@@ -372,7 +372,7 @@ class Gateway(object):
         self.close()
 
     def __del__(self):
-        if (
+        if hasattr(self, "_asynchronous") and (
             not self.asynchronous
             and hasattr(self, "_loop_runner")
             and not sys.is_finalizing()

--- a/dask-gateway/dask_gateway/client.py
+++ b/dask-gateway/dask_gateway/client.py
@@ -372,7 +372,7 @@ class Gateway(object):
         self.close()
 
     def __del__(self):
-        if hasattr(self, "_asynchronous") and (
+        if hasattr(self, "asynchronous") and (
             not self.asynchronous
             and hasattr(self, "_loop_runner")
             and not sys.is_finalizing()


### PR DESCRIPTION
This test was emitting a warning, which came from garbage collection on
Gateway objects that failed in `__init__`.

```pytb
E               Traceback (most recent call last):
E                 File "/home/taugspurger/src/dask/dask-gateway/dask-gateway/dask_gateway/client.py", line 376, in __del__
E                   not self.asynchronous
E                 File "/home/taugspurger/src/dask/dask-gateway/dask-gateway/dask_gateway/client.py", line 334, in asynchronous
E                   return self._asynchronous
E               AttributeError: 'Gateway' object has no attribute '_asynchronous'
```