### PR TITLE
Fix/update pre commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,14 +4,8 @@ repos:
     hooks:
     - id: black
       language_version: python3
-      exclude: versioneer.py
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.2
     hooks:
     - id: flake8
-      language_version: python3
--   repo: https://github.com/pycqa/isort
-    rev: 5.8.0
-    hooks:
-    - id: isort
       language_version: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,17 @@
 repos:
-- repo: https://github.com/ambv/black
-  rev: stable
-  hooks:
+-   repo: https://github.com/psf/black
+    rev: 21.5b1
+    hooks:
     - id: black
-      language_version: python3.7
-
-- repo: https://gitlab.com/pycqa/flake8
-  rev: 3.7.8
-  hooks:
+      language_version: python3
+      exclude: versioneer.py
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.9.2
+    hooks:
     - id: flake8
-      exclude: >
-        (?x)^(
-            demo/dask_gateway_config.py
-        )$
-      language_version: python3.7
+      language_version: python3
+-   repo: https://github.com/pycqa/isort
+    rev: 5.8.0
+    hooks:
+    - id: isort
+      language_version: python3


### PR DESCRIPTION
This updates the pre-commit config to match Dask's (minus isort, which wasn't previously used here).

This fixes an issue I saw locally with the "language_version" and a conda env:

```
An unexpected error has occurred: CalledProcessError: command: ('/home/taugspurger/miniconda3/envs/dask-gateway/bin/python3.8', '-mvirtualenv', '/home/taugspurger/.cache/pre-commit/repoi452dik9/py_env-python3.7', '-p', 'python3.7')
return code: 1
expected return code: 0
stdout:
    RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.7'
```