### PR TITLE
Helm chart: add note about dummy schema

### DIFF
--- a/resources/helm/dask-gateway/crds/daskclusters.yaml
+++ b/resources/helm/dask-gateway/crds/daskclusters.yaml
@@ -18,10 +18,18 @@ spec:
       subresources:
         status: {}
       schema:
+        # NOTE: While we define a schema, it is a dummy schema that doesn't
+        #       validate anything. We just have it to comply with the schema of
+        #       a CustomResourceDefinition that requires it.
+        #
+        #       A decision has been made to not implement an actual schema at
+        #       this point in time due to the additional maintenance work it
+        #       would require.
+        #
+        #       Reference: https://github.com/dask/dask-gateway/issues/434
+        #
         openAPIV3Schema:
           type: object
-          # FIXME: Make this an actual schema instead of this dummy schema that
-          #        is a workaround to meet the requirement of having a schema.
           x-kubernetes-preserve-unknown-fields: true
 status:
   acceptedNames:


### PR DESCRIPTION
Closes #434 by documenting we won't implement a schema for the CRD resources we define.