### PR TITLE
Helm chart: add imagePullSecrets for traefik

### DIFF
--- a/resources/helm/dask-gateway/templates/traefik/deployment.yaml
+++ b/resources/helm/dask-gateway/templates/traefik/deployment.yaml
@@ -98,3 +98,7 @@ spec:
       nodeSelector:
         {{- . | toYaml | nindent 8 }}
       {{- end }}
+      {{- with .Values.traefik.imagePullSecrets }}
+      imagePullSecrets:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}

--- a/resources/helm/dask-gateway/values.schema.yaml
+++ b/resources/helm/dask-gateway/values.schema.yaml
@@ -430,6 +430,7 @@ properties:
     required:
       - replicas
       - image
+      - imagePullSecrets
       - tolerations
       - loglevel
       - dashboard
@@ -448,6 +449,7 @@ properties:
           Set custom image name, tag, pullPolicy, or pullSecrets for Traefik
           running in the `traefik` pod.
         properties: *image-properties
+      imagePullSecrets: *imagePullSecrets-spec
       annotations: *labels-and-annotations-spec
       resources: *resources-spec
       nodeSelector: *nodeSelector-spec

--- a/resources/helm/dask-gateway/values.yaml
+++ b/resources/helm/dask-gateway/values.yaml
@@ -220,6 +220,7 @@ traefik:
     name: traefik
     tag: 2.1.3
     pullPolicy: IfNotPresent
+  imagePullSecrets: []
 
   # Any additional arguments to forward to traefik
   additionalArguments: []


### PR DESCRIPTION
Closes #378 by adding a config provided for the other core pods of a dask-gateway helm chart deployment.