### PR TITLE
point readme test & docs badges to destinations

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,10 +12,10 @@ LICENSE
 New BSD. See the `License File
 <https://github.com/dask/dask-gateway/blob/main/dask-gateway-server/LICENSE>`_.
 
-.. |github-actions-docs| image:: https://github.com/dask/dask-gateway/actions/workflows/docs.yaml/badge.svg
-   :target: https://github.com/dask/dask-gateway/actions/workflows/docs.yaml/badge.svg
 .. |github-actions-tests| image:: https://github.com/dask/dask-gateway/actions/workflows/test.yaml/badge.svg
-   :target: https://github.com/dask/dask-gateway/actions/workflows/test.yaml/badge.svg
+   :target: https://github.com/dask/dask-gateway/actions/workflows/test.yaml
+.. |github-actions-docs| image:: https://github.com/dask/dask-gateway/actions/workflows/docs.yaml/badge.svg
+   :target: https://gateway.dask.org/
 .. |pypi-dask-gateway| image:: https://img.shields.io/pypi/v/dask-gateway.svg?label=dask-gateway
    :target: https://pypi.org/project/dask-gateway/
 .. |pypi-dask-gateway-server| image:: https://img.shields.io/pypi/v/dask-gateway-server.svg?label=dask-gateway-server


### PR DESCRIPTION
*cosmetic change to readme only*

Currently, badge targets are the badges themselves for tests & readme; pypi & conda badges correctly point to destinations

* Rearrange badge image/url definitions to same order as they appear in readme
* replace github actions: tests badge target URL with [/actions/workflows/test.yaml](https://github.com/dask/dask-gateway/actions/workflows/test.yaml)
* replace docs badge target url with documentation