### PR TITLE
Update docker images

### DIFF
--- a/dask-gateway-server/Dockerfile
+++ b/dask-gateway-server/Dockerfile
@@ -6,12 +6,12 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 RUN pip install --no-cache-dir \
-    aiohttp==3.7.4 \
+    aiohttp==3.8.1 \
     colorlog \
     cryptography \
-    traitlets==5.0.5 \
+    traitlets==5.1.1 \
     pyyaml \
-    kubernetes-asyncio==12.1.1
+    kubernetes-asyncio==18.20.0
 
 
 

--- a/dask-gateway/Dockerfile
+++ b/dask-gateway/Dockerfile
@@ -52,8 +52,8 @@ ENTRYPOINT ["tini", "-g", "--"]
 # ** An image with all of dask-gateway's dependencies **
 FROM miniconda as dependencies
 
-ARG DASK_VERSION=2021.8.1
-ARG DISTRIBUTED_VERSION=2021.8.1
+ARG DASK_VERSION=2021.11.2
+ARG DISTRIBUTED_VERSION=2021.11.2
 
 # - Installs dask and dependencies
 # - Cleans up conda files
@@ -61,11 +61,11 @@ ARG DISTRIBUTED_VERSION=2021.8.1
 # - Removes unnecessary *.js.map files
 # - Removes unminified bokeh js
 RUN /opt/conda/bin/conda install -c conda-forge --freeze-installed -y \
-        aiohttp=3.7.4 \
+        aiohttp=3.8.1 \
         dask==$DASK_VERSION \
         distributed==$DISTRIBUTED_VERSION \
-        numpy==1.21.2 \
-        pandas==1.3.2 \
+        numpy==1.21.4 \
+        pandas==1.3.4 \
     && /opt/conda/bin/conda clean -afy \
     && find /opt/conda/ -follow -type f -name '*.a' -delete \
     && find /opt/conda/ -follow -type f -name '*.js.map' -delete \


### PR DESCRIPTION
Updates all pinned packages in the Dockerfiles to their latest released versions.

I *haven't* updated Python from 3.8 to 3.9 or 3.10. Anyone have a preference on that? For now, I think we cut a release with Python 3.8 and then update to 3.9 shortly after the release.