### PR TITLE
CI: Add automation to build/push docker images to ghcr.io (GitHub's container registry)

### DIFF
--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -1,0 +1,83 @@
+name: Create and publish a Docker image
+
+# on:
+#   release:
+#     types:
+#       - created
+on:
+  push:
+    branches: [ "*" ]
+  pull_request:
+    branches: [ "*" ]
+
+
+env:
+  REGISTRY: ghcr.io
+
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        image: [dask-gateway, dask-gateway-server]
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/${{ matrix.image }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: ${{ matrix.image }}
+          # push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.x"
+
+      - name: Install release dependencies
+        run: |
+          python -m pip install --upgrade build twine
+
+      # - name: Build and publish kbatch
+      #   env:
+      #     TWINE_USERNAME: "__token__"
+      #     TWINE_PASSWORD: ${{ secrets.KBATCH_PYPI_PASSWORD }}
+      #   run: |
+      #     cd kbatch
+      #     python -m build
+      #     twine upload dist/*
+
+      # - name: Build and publish kbatch-proxy
+      #   env:
+      #     TWINE_USERNAME: "__token__"
+      #     TWINE_PASSWORD: ${{ secrets.KBATCH_PROXY_PYPI_PASSWORD }}
+      #   run: |
+      #     cd kbatch-proxy
+      #     python -m build
+      #     twine upload dist/*
+      #     cd ..

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -1,19 +1,12 @@
 name: Create and publish a Docker image
 
-# on:
-#   release:
-#     types:
-#       - created
 on:
   push:
-    branches: [ "*" ]
-  pull_request:
-    branches: [ "*" ]
-
+    tags:
+      - "*"
 
 env:
   REGISTRY: ghcr.io
-
 
 jobs:
   build-and-push-image:
@@ -50,34 +43,6 @@ jobs:
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: ${{ matrix.image }}
-          # push: true
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-
-      - name: Set up Python 3.x
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.x"
-
-      - name: Install release dependencies
-        run: |
-          python -m pip install --upgrade build twine
-
-      # - name: Build and publish kbatch
-      #   env:
-      #     TWINE_USERNAME: "__token__"
-      #     TWINE_PASSWORD: ${{ secrets.KBATCH_PYPI_PASSWORD }}
-      #   run: |
-      #     cd kbatch
-      #     python -m build
-      #     twine upload dist/*
-
-      # - name: Build and publish kbatch-proxy
-      #   env:
-      #     TWINE_USERNAME: "__token__"
-      #     TWINE_PASSWORD: ${{ secrets.KBATCH_PROXY_PYPI_PASSWORD }}
-      #   run: |
-      #     cd kbatch-proxy
-      #     python -m build
-      #     twine upload dist/*
-      #     cd ..


### PR DESCRIPTION
This adds a GitHub action to build and push dask-gateway and dask-gateway-server to GitHub container registry on tags.

https://github.com/dask/dask-gateway/runs/4408165500?check_suite_focus=true has the logs from an earlier run that was set to run on all commits, not just tags (but not push). You can see the build output for dask-gateway at https://github.com/dask/dask-gateway/runs/4408165500?check_suite_focus=true#step:6:1.