### PR TITLE
Bump base images

### DIFF
--- a/dask-gateway-server/Dockerfile
+++ b/dask-gateway-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.11-slim-buster as dependencies
+FROM python:3.9-slim-bullseye as dependencies
 LABEL MAINTAINER="Jim Crist-Harif"
 
 RUN apt-get update \

--- a/dask-gateway/Dockerfile
+++ b/dask-gateway/Dockerfile
@@ -1,5 +1,5 @@
 # ** A base miniconda image **
-FROM debian:buster-slim as miniconda
+FROM debian:bullseye-slim as miniconda
 LABEL MAINTAINER="Jim Crist-Harif"
 
 # List of conda versions: https://repo.anaconda.com/miniconda/
@@ -11,7 +11,7 @@ LABEL MAINTAINER="Jim Crist-Harif"
 # FIXME: Use micromamba or mambaforge instead, see
 #        https://github.com/mamba-org/mamba for more info
 #
-ARG CONDA_VERSION=py38_4.9.2
+ARG CONDA_VERSION=py39_4.10.3
 
 # - Create user dask
 RUN useradd -m -U -u 1000 dask

--- a/resources/helm/example-images/Dockerfile
+++ b/resources/helm/example-images/Dockerfile
@@ -12,13 +12,13 @@
 # Note that the version of Python or Python distribution doesn't matter. Here
 # we'll install python via miniconda, then use `conda` to install all
 # dependencies
-FROM debian:buster-slim
+FROM debian:bullseye-slim
 
 # The miniconda version and corresponding SHA256 to use.
 # You can see all available options here:
 # https://docs.conda.io/en/latest/miniconda_hashes.html
-ARG CONDA_VERSION=py38_4.8.3
-ARG CONDA_SHA256=879457af6a0bf5b34b48c12de31d4df0ee2f06a8e68768e5758c3293b2daf688
+ARG CONDA_VERSION=py39_4.10.3
+ARG CONDA_SHA256=1ea2f885b4dbc3098662845560bc64271eb17085387a70c2ba3f29fff6f8d52f
 
 # Does the following in one layer:
 # - Create user dask


### PR DESCRIPTION
- Use Python 3.9 everywhere
- Use latest miniconda
- Bump to using latest debian release