### PR TITLE
ci: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# dependabot.yml reference: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
+#
+# Notes:
+# - Status and logs from dependabot are provided at
+#   https://github.com/dask/dask-gateway/network/updates.
+# - YAML anchors are not supported here or in GitHub Workflows.
+#
+version: 2
+updates:
+  # Update actions in our workflows to their latest releases
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      time: 05:00
+      timezone: Etc/UTC
+    labels:
+      - ci
+      - dependencies


### PR DESCRIPTION
I find dependabot can be noisy if opening PRs daily, but i think weekly and monthly is fine. In this PR I'm adding a dependabot config to bump versions of github workflow's referenced actions.

This can be augmented with dependabot config to bump versions of python packages etc if we extract them to be listed in a requirements.txt / environment.yml file etc.