### PR TITLE
maint/ci: remove support for Python 3.6 and test against multiple versions of Python and Golang

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,16 +30,61 @@ env:
 jobs:
   main-tests:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # We test against different versions of Python and Golang, but not
+          # against different versions of Node.
+          #
+          # - The Python version installed where dask-gateway and
+          #   dask-gateway-proxy is run by the end user matters, so we test
+          #   against all the versions we intend to support.
+          #
+          #   We could for example choose to test against the versions that
+          #   hasn't reached end of life yet: https://endoflife.date/python.
+          #
+          # - The Golang version that compiles
+          #   dask-gateway-server/dask-gateway-proxy bundled for the
+          #   dask-gateway-server Python package is the only thing that matters.
+          #   Due to that, we can test fewer versions of Golang.
+          #
+          #   We could for example choose to test against the versions that
+          #   hasn't reached end of life yet: https://endoflife.date/go.
+          #
+          #   FIXME: Golang 1.16 and above fails because our "go get" isn't
+          #          functioning as before. Golang 1.12 and below fails because
+          #          the stretchr/testify/assert library doesn't support golang
+          #          1.12 and below.
+          #
+          #          About GO111MODULE: https://maelvls.dev/go111module-everywhere/#go-run-knows-about-version-finally
+          #          About go.mod:      https://go.dev/doc/modules/gomod-ref
+          #
+          # - Node is a dependency for JupyterHub's configurable-http-proxy that
+          #   we test integration with. We can test against only one version and
+          #   that would be fine.
+          #
+          - python-version: "3.6"
+            go-version: "1.13"
+          - python-version: "3.7"
+            go-version: "1.14"
+          - python-version: "3.8"
+            go-version: "1.15"
+          - python-version: "3.9"
+            go-version: "1.15"
+          - python-version: "3.10"
+            go-version: "1.15"
+
     steps:
       - uses: actions/checkout@v3
 
       - uses: actions/setup-python@v3
         with:
-          python-version: "3.8"
+          python-version: "${{ matrix.python-version }}"
 
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.14"
+          go-version: "${{ matrix.go-version }}"
 
       - uses: actions/setup-node@v3
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -64,8 +64,6 @@ jobs:
           #   we test integration with. We can test against only one version and
           #   that would be fine.
           #
-          - python-version: "3.6"
-            go-version: "1.13"
           - python-version: "3.7"
             go-version: "1.14"
           - python-version: "3.8"

--- a/dask-gateway-server/setup.py
+++ b/dask-gateway-server/setup.py
@@ -136,8 +136,10 @@ setup(
         "Topic :: System :: Distributed Computing",
         "Topic :: System :: Systems Administration",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     keywords="dask hadoop kubernetes HPC distributed cluster",
     description=(
@@ -157,7 +159,7 @@ setup(
     package_data=package_data,
     install_requires=install_requires,
     extras_require=extras_require,
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     entry_points={
         "console_scripts": [
             "dask-gateway-server = dask_gateway_server.app:main",

--- a/dask-gateway/setup.py
+++ b/dask-gateway/setup.py
@@ -30,8 +30,10 @@ setup(
         "Topic :: Scientific/Engineering",
         "Topic :: System :: Distributed Computing",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     keywords="dask hadoop kubernetes HPC distributed cluster",
     description="A client library for interacting with a dask-gateway server",
@@ -48,5 +50,6 @@ setup(
     package_data={"dask_gateway": ["*.yaml"]},
     install_requires=install_requires,
     extras_require=extras_require,
+    python_requires=">=3.7",
     zip_safe=False,
 )


### PR DESCRIPTION
I wanted to better understand if this Python code functioned in Python 3.6-3.10, as well as if its associated Golang code in dask-gateway-server/dask-gateway-proxy would function to compile with Golang 1.12-1.18.

I couldn't arrive at a clear conclusion about Golang, but we seem to be fine with Python 3.6-3.10. A key reason that we don't properly test against all versions of Golang is that we have golang versions in many different contexts. For example, we have it in the Dockerfile's defined to start slurm/pbs/hadoop to test against them.

I raised the question if we should drop support for Python 3.6 which has reached end of life three months ago in #498. I think it makes sense to do so at this point in time.

---

This PR is also updated to remove support for Python 3.6 which has reached end of life.