### PR TITLE
Remove legacy purge flag from k8s uninstall docs

### DIFF
--- a/docs/source/install-kube.rst
+++ b/docs/source/install-kube.rst
@@ -184,7 +184,7 @@ clean everything up. You can do this with ``helm delete``:
 
 .. code-block:: shell
 
-    $ helm delete --purge $RELEASE
+    $ helm delete $RELEASE
 
 
 Additional configuration


### PR DESCRIPTION
Minor doc fix!

The [install instructions for dask-gateway on Kubernetes](https://gateway.dask.org/install-kube.html#shutting-everything-down) use an unsupported flag (`--purge`) in the `helm` command for cleanup and uninstalling work. When run, this throws an error at the poor user.

This updates the docs to remove the `--purge` flag. No other change is needed because behavior from `--purge` is the default behavior in the current version of `helm`.