### PR TITLE
ci: run go native tests against modern versions of go

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,26 +52,18 @@ jobs:
           #   We could for example choose to test against the versions that
           #   hasn't reached end of life yet: https://endoflife.date/go.
           #
-          #   FIXME: Golang 1.16 and above fails because our "go get" isn't
-          #          functioning as before. Golang 1.12 and below fails because
-          #          the stretchr/testify/assert library doesn't support golang
-          #          1.12 and below.
-          #
-          #          About GO111MODULE: https://maelvls.dev/go111module-everywhere/#go-run-knows-about-version-finally
-          #          About go.mod:      https://go.dev/doc/modules/gomod-ref
-          #
           # - Node is a dependency for JupyterHub's configurable-http-proxy that
           #   we test integration with. We can test against only one version and
           #   that would be fine.
           #
           - python-version: "3.7"
-            go-version: "1.14"
+            go-version: "1.15"
           - python-version: "3.8"
-            go-version: "1.15"
+            go-version: "1.16"
           - python-version: "3.9"
-            go-version: "1.15"
+            go-version: "1.17"
           - python-version: "3.10"
-            go-version: "1.15"
+            go-version: "1.18"
 
     steps:
       - uses: actions/checkout@v3
@@ -86,9 +78,8 @@ jobs:
 
       - uses: actions/setup-node@v3
 
-      - name: Install requirements
+      - name: Install Python test requirements
         run: |
-          go get github.com/stretchr/testify/assert
           source continuous_integration/install.sh
 
       - name: List Python packages
@@ -99,11 +90,15 @@ jobs:
         run: |
           py.test tests/ -k 'not kubernetes' -v
 
+      - name: Install Go test requirements
+        run: |
+          cd dask-gateway-server/dask-gateway-proxy
+          go get github.com/stretchr/testify/assert
+
       - name: Run Go tests
         run: |
-          pushd dask-gateway-server/dask-gateway-proxy
+          cd dask-gateway-server/dask-gateway-proxy
           go test
-          popd
 
   hadoop-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I didn't understand enough about go to successfully run the go native tests defined in dask-gateway-server/dask-gateway-proxy against versions 1.16+. I've now pieced together some additional understanding to get this to work. I think the gist was that we had to install golang test dependencies part of the project, and not globally for Go 1.16+.

This could perhaps be worked around by having a global environment variable GO111MODULE=auto, or setup the test dependencies in another way somehow? I'm not sure. For now, this change to run `go get` from the folder with the golang code seems like a good resolution that seem to work for many versions of golang.