### PR TITLE
debug ci failure: mix used versions to rule out go 1.15 or py37 as the culprit

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,13 +57,13 @@ jobs:
           #   that would be fine.
           #
           - python-version: "3.7"
-            go-version: "1.16"
+            go-version: "1.15"
           - python-version: "3.8"
             go-version: "1.15"
           - python-version: "3.9"
-            go-version: "1.17"
+            go-version: "1.15"
           - python-version: "3.10"
-            go-version: "1.18"
+            go-version: "1.15"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,9 +57,9 @@ jobs:
           #   that would be fine.
           #
           - python-version: "3.7"
-            go-version: "1.15"
-          - python-version: "3.8"
             go-version: "1.16"
+          - python-version: "3.8"
+            go-version: "1.15"
           - python-version: "3.9"
             go-version: "1.17"
           - python-version: "3.10"

--- a/dask-gateway/Dockerfile
+++ b/dask-gateway/Dockerfile
@@ -1,5 +1,5 @@
 # ** A base miniconda image **
-FROM debian:bullseye-slim as miniconda
+FROM debian:11.2-slim as miniconda
 LABEL MAINTAINER="Jim Crist-Harif"
 
 # List of conda versions: https://repo.anaconda.com/miniconda/


### PR DESCRIPTION
This is a dummy PR to help debug #522 and shouldn't be merged.