### PR TITLE
maint: avoid regression/breaking change in `click` and declare our dependency to the library explicitly

### DIFF
--- a/continuous_integration/install.sh
+++ b/continuous_integration/install.sh
@@ -7,6 +7,7 @@ npm install -g configurable-http-proxy
 # entries in ../dev-environment.yaml
 pip install -U \
     aiohttp \
+    "click<8.1.0" \
     colorlog \
     cryptography \
     dask \

--- a/dask-gateway/Dockerfile
+++ b/dask-gateway/Dockerfile
@@ -64,11 +64,12 @@ ARG DISTRIBUTED_VERSION=2022.02.0
 # - Removes unnecessary *.js.map files
 # - Removes unminified bokeh js
 RUN /opt/conda/bin/conda install -c conda-forge --freeze-installed -y \
-        aiohttp=3.8.1 \
-        dask==$DASK_VERSION \
-        distributed==$DISTRIBUTED_VERSION \
-        numpy==1.21.4 \
-        pandas==1.3.4 \
+        "aiohttp==3.8.1" \
+        "click<8.1.0" \
+        "dask==$DASK_VERSION" \
+        "distributed==$DISTRIBUTED_VERSION" \
+        "numpy==1.21.4" \
+        "pandas==1.3.4" \
     && /opt/conda/bin/conda clean -afy \
     && find /opt/conda/ -follow -type f -name '*.a' -delete \
     && find /opt/conda/ -follow -type f -name '*.js.map' -delete \

--- a/dask-gateway/setup.py
+++ b/dask-gateway/setup.py
@@ -9,7 +9,18 @@ with open(os.path.join(here, "dask_gateway", "_version.py")) as f:
 
 # NOTE: changes to the dependencies here must also be reflected
 # in ../dev-environment.yaml
-install_requires = ["aiohttp", "dask>=2.2.0", "distributed>=2.2.0", "tornado"]
+install_requires = [
+    "aiohttp",
+    # FIXME: click 8.0.4 works, but 8.1.0-8.1.2 has found to cause failures for
+    #        currently unknown reasons.
+    #
+    #        This is tracked in https://github.com/dask/dask-gateway/issues/522.
+    #
+    "click<8.1.0",
+    "dask>=2.2.0",
+    "distributed>=2.2.0",
+    "tornado",
+]
 
 extras_require = {
     "kerberos": [

--- a/dev-environment.yaml
+++ b/dev-environment.yaml
@@ -13,6 +13,7 @@ dependencies:
   # - dask-gateway/setup.py
   # - dask-gateway-server/setup.py
   - aiohttp # dask-gateway, dask-gateway-server
+  - click<8.1.0 # dask-gateway
   - dask # dask-gateway
   - distributed # dask-gateway
   - tornado # dask-gateway, dask-gateway-server


### PR DESCRIPTION
dask-gateway was dependent on click, but we didn't declare that dependency explicitly but instead relied on it showing up as a dependency from something else we had installed. Since we have a direct `import click` statement in the dask-gateway project, I suggest it is listed explicitly as a dependency like done in this PR now.

As part of listing `click` as an explicit dependency, we also pin it to avoid 8.1.0-8.1.2 which breaks things for us as discussed in #522.