### PR TITLE
Add /api/v1/routes_initialized to help proxy process report readiness

### DIFF
--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -34,7 +34,7 @@ class temp_proxy:
         await self.runner.setup()
         self.site = web.TCPSite(self.runner, "127.0.0.1", self._port)
         await self.site.start()
-        await self.proxy._proxy_contacted
+        await self.proxy._proxy_routes_initialized
         return self.proxy
 
     async def __aexit__(self, *args):

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -60,7 +60,7 @@ class temp_gateway:
         self.gateway = DaskGateway(config=self.config)
         self.gateway.initialize([])
         await self.gateway.setup()
-        await self.gateway.backend.proxy._proxy_contacted
+        await self.gateway.backend.proxy._proxy_routes_initialized
         self.address = f"http://{self.gateway.backend.proxy.address}"
         self.proxy_address = f"gateway://{self.gateway.backend.proxy.tcp_address}"
         return self


### PR DESCRIPTION
This resolves part of #422, an intermittent error stemming from `404 NOT FOUND` responses.

The issue was that the Golang proxy binary that was started in a separate process was only partially awaited. It was awaited to contact `/api/v1/routes` but not to have initialized its routes based on a response. See https://github.com/dask/dask-gateway/issues/422#issuecomment-1100606030 for investigation notes about this.

## This PR: await notification

In this PR I've opted to resolve this by a quite robust implementation where the Golang proxy binary running in a separate process reports that its routes are initialized after they are. Doing so comes with the complexity of adding an additional web-server API endpoint and making another web request from the Golang proxy binary.

```diff
     async def __aenter__(self):
         self.gateway = DaskGateway(config=self.config)
         self.gateway.initialize([])
         await self.gateway.setup()
-        await self.gateway.backend.proxy._proxy_contacted
+        await self.gateway.backend.proxy._proxy_routes_initialized
```

Closes #530

## An alternative PR: sleep some (#530)

An alternative to this implementation would be to sleep some duration, for example after the previous `_proxy_contacted` flag was awaited to be set. If we would go for this approach, maybe we test with a sleep of 0.25 seconds, then double it until we no longer observe these intermittent tests, and make a comment linking to this then closed PR about the motivation for sleeping.

```diff
     async def __aenter__(self):
         self.gateway = DaskGateway(config=self.config)
         self.gateway.initialize([])
         await self.gateway.setup()
         await self.gateway.backend.proxy._proxy_contacted
+        await asyncio.sleep(0.25)
```