### PR TITLE
Fix intermittent errors by sleeping a bit before running tests

### DIFF
--- a/tests/test_proxies.py
+++ b/tests/test_proxies.py
@@ -35,6 +35,11 @@ class temp_proxy:
         self.site = web.TCPSite(self.runner, "127.0.0.1", self._port)
         await self.site.start()
         await self.proxy._proxy_contacted
+        # Awaiting _proxy_contacted isn't failsafe and can lead to "ValueError,
+        # 404 NOT FOUND" if not complemented with a sufficiently long sleep
+        # following it. See https://github.com/dask/dask-gateway/pull/529 for a
+        # discussion on this.
+        await asyncio.sleep(0.25)
         return self.proxy
 
     async def __aexit__(self, *args):

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -61,6 +61,11 @@ class temp_gateway:
         self.gateway.initialize([])
         await self.gateway.setup()
         await self.gateway.backend.proxy._proxy_contacted
+        # Awaiting _proxy_contacted isn't failsafe and can lead to "ValueError,
+        # 404 NOT FOUND" if not complemented with a sufficiently long sleep
+        # following it. See https://github.com/dask/dask-gateway/pull/529 for a
+        # discussion on this.
+        await asyncio.sleep(0.25)
         self.address = f"http://{self.gateway.backend.proxy.address}"
         self.proxy_address = f"gateway://{self.gateway.backend.proxy.tcp_address}"
         return self


### PR DESCRIPTION
This is an alternative approach to #529 to avoiding the ValueError 404 NOT FOUND as described in #422.

Feel free to merge either alternative. Refer to #529 for an overview of the choice. Closes #529.

Note that with a sleep duration of 0.25, we have not experienced any failures related to 404 NOT FOUND in 3/3 workflows executions.