### PR TITLE
Drop support for Python 3.7

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,8 +57,6 @@ jobs:
           #   we test integration with. We can test against only one version and
           #   that would be fine.
           #
-          - python-version: "3.7"
-            go-version: "1.15"
           - python-version: "3.8"
             go-version: "1.16"
           - python-version: "3.9"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     hooks:
       - id: pyupgrade
         args:
-          - --py37-plus
+          - --py38-plus
 
   # Autoformat: Python code
   - repo: https://github.com/psf/black

--- a/dask-gateway-server/dask_gateway_server/backends/local.py
+++ b/dask-gateway-server/dask_gateway_server/backends/local.py
@@ -54,7 +54,7 @@ async def wait_is_shutdown(pid, timeout=10):
     return False
 
 
-@functools.lru_cache()
+@functools.lru_cache
 def getpwnam(username):
     return pwd.getpwnam(username)
 

--- a/dask-gateway-server/setup.py
+++ b/dask-gateway-server/setup.py
@@ -151,7 +151,6 @@ setup(
         "Topic :: System :: Distributed Computing",
         "Topic :: System :: Systems Administration",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -174,7 +173,7 @@ setup(
     package_data=package_data,
     install_requires=install_requires,
     extras_require=extras_require,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     entry_points={
         "console_scripts": [
             "dask-gateway-server = dask_gateway_server.app:main",

--- a/dask-gateway/setup.py
+++ b/dask-gateway/setup.py
@@ -44,7 +44,6 @@ setup(
         "Topic :: Scientific/Engineering",
         "Topic :: System :: Distributed Computing",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
@@ -64,6 +63,6 @@ setup(
     package_data={"dask_gateway": ["*.yaml"]},
     install_requires=install_requires,
     extras_require=extras_require,
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     zip_safe=False,
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.black]
 line-length = 88
 # target-version should be all supported versions
-target-version = ['py37', 'py38', 'py39', 'py310']
+target-version = ['py38', 'py39', 'py310']
 
 [tool.pytest.ini_options]
 # GitHub Actions make it hard for pytest to conclude it should use colors, due


### PR DESCRIPTION
Closes #498

I suggest the intermittent test failures are to be resolved by #530. I'm opting to not re-run all intermittently failed tests in this PR, there is a successful test in one Python version at least that didn't intermittently fail.

EDIT: Went for a self merge, I think there is agreement about this already in #498.