### PR TITLE
Reference distributed's actual TimeoutError used

### DIFF
--- a/dask-gateway-server/dask_gateway_server/backends/inprocess.py
+++ b/dask-gateway-server/dask_gateway_server/backends/inprocess.py
@@ -1,7 +1,7 @@
 from dask_gateway.scheduler_preload import make_gateway_client, GatewaySchedulerService
 from distributed import Security, Scheduler, Worker
 from distributed.core import Status
-from tornado import gen
+from distributed.utils import TimeoutError
 
 from .local import UnsafeLocalBackend
 
@@ -100,7 +100,7 @@ class InProcessBackend(UnsafeLocalBackend):
             return
         try:
             await worker.close(timeout=1)
-        except gen.TimeoutError:
+        except TimeoutError:
             pass
 
     async def do_check_workers(self, workers):

--- a/dask-gateway-server/setup.py
+++ b/dask-gateway-server/setup.py
@@ -103,7 +103,6 @@ install_requires = [
     "aiohttp",
     "colorlog",
     "cryptography",
-    "tornado",
     "traitlets",
 ]
 

--- a/dask-gateway/setup.py
+++ b/dask-gateway/setup.py
@@ -18,7 +18,7 @@ install_requires = [
     #
     "click<8.1.0",
     "dask>=2.2.0",
-    "distributed>=2.2.0",
+    "distributed>=2021.01.1",
     "pyyaml",
     "tornado",
 ]

--- a/dev-environment.yaml
+++ b/dev-environment.yaml
@@ -15,9 +15,9 @@ dependencies:
   - aiohttp # dask-gateway, dask-gateway-server
   - click<8.1.0 # dask-gateway
   - dask # dask-gateway
-  - distributed # dask-gateway
+  - distributed>=2021.01.1 # dask-gateway
   - pyyaml # dask-gateway
-  - tornado # dask-gateway, dask-gateway-server
+  - tornado # dask-gateway
   - colorlog # dask-gateway-server
   - cryptography # dask-gateway-server
   - traitlets # dask-gateway-server


### PR DESCRIPTION
Closes #515 by relying on a change in https://github.com/dask/distributed/pull/3394 which is released and part of distributed 2021.01.21.

By referencing the TimeoutError as defined by the distributed package, we don't have to install tornado as part of dask-gateway-server any more.

---

Note that this will have various merge conflicts with other PRs i have open. Prefer if those are merged before this to make me fix the conflicts in this PR instead of those.

- #533
- #532
- #531
- #530

EDIT: Going for a self-merge of this now and rebasing the others for cleaner merge of those that may merit more review and agreement.