### PR TITLE
Fix failure to start api/controller pods with tini as an entrypoint

### DIFF
--- a/resources/helm/dask-gateway/templates/controller/deployment.yaml
+++ b/resources/helm/dask-gateway/templates/controller/deployment.yaml
@@ -43,7 +43,7 @@ spec:
         - name: controller
           image: {{ .Values.controller.image.name }}:{{ .Values.controller.image.tag }}
           imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
-          command:
+          args:
             - dask-gateway-server
             - kube-controller
             - --config

--- a/resources/helm/dask-gateway/templates/gateway/deployment.yaml
+++ b/resources/helm/dask-gateway/templates/gateway/deployment.yaml
@@ -42,7 +42,7 @@ spec:
         - name: gateway
           image: {{ .Values.gateway.image.name }}:{{ .Values.gateway.image.tag }}
           imagePullPolicy: {{ .Values.gateway.image.pullPolicy }}
-          command:
+          args:
             - dask-gateway-server
             - --config
             - /etc/dask-gateway/dask_gateway_config.py


### PR DESCRIPTION
`ENTRYPOINT` in a Dockerfile maps to `command` in a k8s Pod specification, and `CMD` in a Dockerfile maps to `args` in a k8s Pod specification. By defining `args` instead of `command`, we override the image's `CMD` but not its `ENTRYPOINT` and like that we end up successfully using `tini` as an entrypoint.

This change relates to this Dockerfile, that has a `ENTRYPOINT` aka `command` set to use `tini`.

https://github.com/dask/dask-gateway/blob/fd2ada0f1d3fdd3428a60a690781bae252529b83/dask-gateway-server/Dockerfile#L44-L45