### PR TITLE
ci: avoid running tests in fork's PR branches

### DIFF
--- a/.github/workflows/build-publish-docs.yaml
+++ b/.github/workflows/build-publish-docs.yaml
@@ -16,9 +16,7 @@ on:
       - "dask-gateway/**"
       - "dask-gateway-server/**"
       - ".github/workflows/build-publish-docs.yaml"
-    branches-ignore:
-      - "dependabot/**"
-      - "pre-commit-ci-update-config"
+    branches: ["main"]
     tags: ["**"]
   workflow_dispatch:
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,9 +18,7 @@ on:
       - "**.rst"
       - ".github/workflows/*"
       - "!.github/workflows/test.yaml"
-    branches-ignore:
-      - "dependabot/**"
-      - "pre-commit-ci-update-config"
+    branches: ["main"]
     tags: ["**"]
   workflow_dispatch:
 


### PR DESCRIPTION
If tests are run in a fork, they will fail, as they don't have access to the semi-private testing images. When that fail happen, it will be seen as a red cross on the commit even before the pull_request triggered tests has completed. Like this, we save some compute by not running things twice and we avoid test failure notifications etc.

### About semi-private images

The `ghcr.io/dask/dask-gateway-ci-hadoop` image and other `ghcr.io/dask/dask-gateway-ci-` images are marked as private, but we have also made them available to PRs in this repo. So, they are private to not draw attention rather than being secret.

### Screenshots from errors we avoid with this PR

![image](https://user-images.githubusercontent.com/3837114/163886927-7c3e7917-64ba-45d8-a12d-d515dad93f02.png)

![image](https://user-images.githubusercontent.com/3837114/163887113-1363be79-b714-4eab-b7b1-d5bba3958566.png)

![image](https://user-images.githubusercontent.com/3837114/163887189-ae6492be-c76f-4a8d-860c-a33c82edf628.png)
