### PR TITLE
Disable arm64 for dask/dask-gateway image

### DIFF
--- a/resources/helm/chartpress.yaml
+++ b/resources/helm/chartpress.yaml
@@ -27,6 +27,11 @@ charts:
         contextPath: ../../dask-gateway
         valuesPath:
           - gateway.backend.image
+        # FIXME: psutils, a dependency of distributed, currently doesn't have wheels
+        #        for arm64 and requires `gcc` and `python3-dev` of a compatible version
+        #        of python (python 3.9 for debian bullseye).
+        skipPlatforms:
+          - linux/arm64
       # Used for the api and controller pods
       dask-gateway-server:
         imageName: ghcr.io/dask/dask-gateway-server


### PR DESCRIPTION
dask/distributed has a dependency on `psutils`, which requires a bit things to install that I don't want to clutter our primitive dask/dask-gateway image with. Its not so important that we have an arm64 image for dask/dask-gateway, as its used as a sample image for scheduler/worker pods and not critical to the helm charts function or our CI system that only runs on amd64 architecture.