### PR TITLE
maint: unpin click again as issues seems resolved

### DIFF
--- a/dask-gateway/requirements.txt
+++ b/dask-gateway/requirements.txt
@@ -4,12 +4,7 @@
 #       ../dev-environment.yaml
 #
 aiohttp
-# FIXME: click 8.0.4 works, but 8.1.0-8.1.2 has found to cause failures for
-#        currently unknown reasons.
-#
-#        This is tracked in https://github.com/dask/dask-gateway/issues/522.
-#
-click<8.1.0
+click
 dask>=2.2.0
 distributed>=2021.01.1
 pyyaml


### PR DESCRIPTION
Closes #526, but I don't get why tests started going green after pinning click but now again seems to do fine after unpinning it again. Hmmm, I presume it related to some dependency conflict in between click and some other dependency - that would make sense.

Since things work like it is now, and worked before, I'll go for a merge and consider this resolved as something fixed in some unknown dependency.