### PR TITLE
Document setting `display: False` in hub services config

### DIFF
--- a/docs/source/install-kube.rst
+++ b/docs/source/install-kube.rst
@@ -348,7 +348,7 @@ JupyterHub Helm Chart.
          apiToken: "<API TOKEN>"
          display: false
 
-again, replacing ``<API TOKEN>`` with the output from above. The `display`
+again, replacing ``<API TOKEN>`` with the output from above. The ``display``
 attribute hides dask-gateway from the 'Services' dropdown in the hub home
 page, as dask-gateway doesn't offer any useful UI features.
 


### PR DESCRIPTION
Otherwise, a very confusing dask-gateway entry is provided under
'services' in the hub home page for the user.

Ref https://github.com/2i2c-org/infrastructure/issues/1301