### PR TITLE
Update docs theme for rebranding

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,7 +6,7 @@
 #   cd docs
 #   make html
 #
-dask-sphinx-theme
+dask-sphinx-theme>=3.0.0
 myst-parser
 sphinx
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -12,7 +12,9 @@ release = version = dask_gateway_server.__version__
 source_suffix = [".rst", ".md"]
 root_doc = master_doc = "index"
 language = None
-pygments_style = "sphinx"
+# Commenting this out for now, if we register dask pygments,
+# then eventually this line can be:
+# pygments_style = "dask"
 exclude_patterns = []
 
 # Sphinx Extensions


### PR DESCRIPTION
On Monday, June 6th, dask.org will go live with a new design (see https://github.com/dask/community/issues/220). This PR is in preparation for the theme update for `dask-sphinx-theme` and can be merged in *after* https://github.com/dask/dask-sphinx-theme/pull/67 on Monday.

cc @jacobtomlinson @jsignell