### PR TITLE
Let Traefik's route traffic across namespaces via IngressRoute resources

### DIFF
--- a/resources/helm/dask-gateway/templates/traefik/deployment.yaml
+++ b/resources/helm/dask-gateway/templates/traefik/deployment.yaml
@@ -44,6 +44,7 @@ spec:
             - "--global.sendanonymoususage=False"
             - "--ping=true"
             - "--providers.kubernetescrd"
+            - "--providers.kubernetescrd.allowCrossNamespace=true"
             - '--providers.kubernetescrd.labelselector=gateway.dask.org/instance={{ include "dask-gateway.fullname" . }}'
             - "--providers.kubernetescrd.throttleduration=2"
             - "--log.level={{ .Values.traefik.loglevel }}"


### PR DESCRIPTION
Hello,

Setting allowCrossNamespace=true fixes https://github.com/dask/dask-gateway/issues/568

see https://doc.traefik.io/traefik/providers/kubernetes-crd/#allowcrossnamespace

Not 100% sure of the security implication of that setting - would it be preferable to gate it behind a chart parameter?

Cheers,

Olivier