### PR TITLE
Update Dask logo

### DIFF
--- a/resources/helm/dask-gateway/Chart.yaml
+++ b/resources/helm/dask-gateway/Chart.yaml
@@ -7,5 +7,5 @@ description: A multi-tenant server for deploying and managing Dask clusters
 home: https://gateway.dask.org/
 sources:
   - https://github.com/dask/dask-gateway/
-icon: https://docs.dask.org/en/latest/_images/dask_icon_no_pad.svg
+icon: https://avatars3.githubusercontent.com/u/17131925?v=3&s=200
 kubeVersion: ">=1.20.0-0"


### PR DESCRIPTION
Today we released the new Dask logo. However the helm chart is still showing the old one.

The other helm charts point to the GitHub avatar so updating things here. This means if it gets tweaked or altered again in the future it will not need updating again.