### PR TITLE
Fix compatibility with distributed >= 2022.5.1 and traitlets >= 5.2.0, and raise the lower bound of required versions

### DIFF
--- a/dask-gateway-server/dask_gateway_server/app.py
+++ b/dask-gateway-server/dask_gateway_server/app.py
@@ -13,7 +13,7 @@ from .auth import Authenticator
 from .backends import Backend
 from .routes import default_routes
 from .traitlets import Application, Type
-from .utils import AccessLogger, LogFormatter, classname, normalize_address, run_main
+from .utils import AccessLogger, classname, normalize_address, run_main
 
 
 class GenerateConfig(Application):
@@ -144,8 +144,6 @@ class DaskGateway(Application):
     @validate("address")
     def _validate_address(self, proposal):
         return normalize_address(proposal.value)
-
-    _log_formatter_cls = LogFormatter
 
     classes = List([Backend, Authenticator])
 

--- a/dask-gateway-server/dask_gateway_server/backends/inprocess.py
+++ b/dask-gateway-server/dask_gateway_server/backends/inprocess.py
@@ -69,7 +69,7 @@ class InProcessBackend(UnsafeLocalBackend):
     async def do_stop_cluster(self, cluster):
         scheduler = self.schedulers.pop(cluster.name)
 
-        await scheduler.close(fast=True)
+        await scheduler.close()
         scheduler.stop()
 
         workdir = cluster.state.get("workdir")

--- a/dask-gateway-server/dask_gateway_server/backends/kubernetes/controller.py
+++ b/dask-gateway-server/dask_gateway_server/backends/kubernetes/controller.py
@@ -20,7 +20,6 @@ from ...traitlets import Application
 from ...utils import (
     AccessLogger,
     FrozenAttrDict,
-    LogFormatter,
     RateLimiter,
     TaskPool,
     normalize_address,
@@ -283,8 +282,6 @@ class KubeController(KubeBackendAndControllerMixin, Application):
         help="A list of middlewares to apply to web routes added to the proxy.",
         config=True,
     )
-
-    _log_formatter_cls = LogFormatter
 
     # Fail if the config file errors
     raise_config_file_errors = True

--- a/dask-gateway-server/dask_gateway_server/traitlets.py
+++ b/dask-gateway-server/dask_gateway_server/traitlets.py
@@ -3,7 +3,22 @@ from traitlets import Type as _Type
 from traitlets import Unicode
 from traitlets.config import Application
 
-# Override default values for logging
+# We replace the class of the default formatter used via a configuration change.
+#
+# References:
+#
+# - Traitlets' Application.logging_config defaults:
+#   https://github.com/ipython/traitlets/blob/e2c731ef72dd41d4be527d4d93dd87ccc409830d/traitlets/config/application.py#L229-L256
+# - Python official schema for Application.logging_config:
+#   https://docs.python.org/3/library/logging.config.html#logging-config-dictschema
+#
+Application.logging_config = {
+    "formatters": {
+        "console": {
+            "class": "dask_gateway_server.utils.LogFormatter",
+        },
+    },
+}
 Application.log_level.default_value = "INFO"
 Application.log_format.default_value = (
     "%(log_color)s[%(levelname)1.1s %(asctime)s.%(msecs).03d "

--- a/dask-gateway-server/dask_gateway_server/utils.py
+++ b/dask-gateway-server/dask_gateway_server/utils.py
@@ -175,10 +175,11 @@ def classname(cls):
 
 
 class LogFormatter(ColoredFormatter):
-    def __init__(self, fmt=None, datefmt=None):
+    def __init__(self, fmt=None, datefmt=None, style=None):
         super().__init__(
             fmt=fmt,
             datefmt=datefmt,
+            style=style,
             reset=False,
             log_colors={
                 "DEBUG": "blue",

--- a/dask-gateway-server/requirements.txt
+++ b/dask-gateway-server/requirements.txt
@@ -3,4 +3,4 @@
 aiohttp
 colorlog
 cryptography
-traitlets
+traitlets>=5.2.2.post1

--- a/dask-gateway/requirements.txt
+++ b/dask-gateway/requirements.txt
@@ -3,6 +3,6 @@
 aiohttp
 click
 dask>=2.2.0
-distributed>=2021.01.1
+distributed>=2022.5.2
 pyyaml
 tornado

--- a/dask-gateway/requirements.txt
+++ b/dask-gateway/requirements.txt
@@ -1,8 +1,8 @@
 # These are dependencies for installing the dask-gateway package.
 #
 aiohttp
-click
-dask>=2.2.0
+click>=8.1.3
+dask>=2022.5.2
 distributed>=2022.5.2
 pyyaml
 tornado

--- a/dask-gateway/requirements.txt
+++ b/dask-gateway/requirements.txt
@@ -2,7 +2,7 @@
 #
 aiohttp
 click>=8.1.3
-dask>=2022.5.2
-distributed>=2022.5.2
+dask>=2022.1.0
+distributed>=2022.1.0,!=2022.5.1,!=2022.5.2
 pyyaml
 tornado

--- a/tests/test_db_backend.py
+++ b/tests/test_db_backend.py
@@ -469,7 +469,7 @@ async def test_cluster_fails_after_connect():
             async with gateway.new_cluster() as cluster:
                 # Kill scheduler
                 scheduler = g.gateway.backend.schedulers[cluster.name]
-                await scheduler.close(fast=True)
+                await scheduler.close()
                 scheduler.stop()
 
                 # Gateway notices and cleans up cluster in time


### PR DESCRIPTION
Closes #571.

I've observed a flurry of issues that created a very hard to debug situation, but this resolves them all I think. This patch makes us require modern versions of `distributed`, `traitlets`, `click`, and `dask` though. Unless we have tests against the minimum required versions, I think its better that we do this than hope a version could be slightly lower without issues though.

---

The `click` issue as seen on a scheduler pod starting and quickly terminating.

```
Traceback (most recent call last):
  File "/srv/conda/envs/notebook/bin/dask-scheduler", line 8, in <module>
    sys.exit(go())
  File "/srv/conda/envs/notebook/lib/python3.9/site-packages/distributed/cli/dask_scheduler.py", line 216, in go
    check_python_3()
  File "/srv/conda/envs/notebook/lib/python3.9/site-packages/distributed/cli/utils.py", line 39, in check_python_3
    from click import _unicodefun
ImportError: cannot import name '_unicodefun' from 'click' (/srv/conda/envs/notebook/lib/python3.9/site-packages/click/__init__.py)
```