### PR TITLE
Update dask-gateway package's requirements to what works

### DIFF
--- a/dask-gateway/requirements.txt
+++ b/dask-gateway/requirements.txt
@@ -2,7 +2,7 @@
 #
 aiohttp
 click>=8.1.3
-dask>=2022.1.0
-distributed>=2022.1.0,!=2022.5.1,!=2022.5.2
+dask>=2022.4.0
+distributed>=2022.4.0
 pyyaml
 tornado


### PR DESCRIPTION
### Changes

- `dask-gateway` the client apparently requires >=2022.4.0 to function, this PR adjusts the requirements declared to that.

  I've manually run a lot of tests to conclude this. This could be resolved by #539 though.

- `dask-gateway` the client can function with ==2022.5.1 and ==2022.5.2 even though #573 incorrectly made the client require some other version while also fixing the incompatibility with those versions.