### PR TITLE
Add changelog for 2022.6.1

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 2022.6.1
+
+### Bugs fixed
+
+- Update dask-gateway package's requirements to what works [#580](https://github.com/dask/dask-gateway/pull/580) ([@consideRatio](https://github.com/consideRatio))
+
+### Other merged PRs
+
+- ci: avoid 429 too-many-requests issues from linkcheck [#578](https://github.com/dask/dask-gateway/pull/578) ([@consideRatio](https://github.com/consideRatio))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/dask/dask-gateway/graphs/contributors?from=2022-06-13&to=2022-06-13&type=c))
+
+[@consideRatio](https://github.com/search?q=repo%3Adask%2Fdask-gateway+involves%3AconsideRatio+updated%3A2022-06-13..2022-06-13&type=Issues) | [@martindurant](https://github.com/search?q=repo%3Adask%2Fdask-gateway+involves%3Amartindurant+updated%3A2022-06-13..2022-06-13&type=Issues)
+
 ## 2022.6.0
 
 This release makes `dask-gateway` the client require `dask>=2022`,


### PR DESCRIPTION
2022.6.0 was released, but I was frustrated about a mistake I realized I made. I constrainted dask-gateway the client to not use distributed 2022.5.1 and 2022.5.2 while in the same PR I made dask-gateway the client compatible with those version, making the constraint not needed.

While verifying that we did now have support for distributed==2022.5.1 and 2022.5.2, I also concluded that the lower bound were still too optimistic, and we in practice require distributed>=2022.4.0. So, in https://github.com/dask/dask-gateway/pull/580 that was resolved, and I'll go for a 2022.6.1 release.