### PR TITLE
Helm chart: add imagePullSecrets for gateway.backend

### DIFF
--- a/dask-gateway-server/dask_gateway_server/backends/kubernetes/backend.py
+++ b/dask-gateway-server/dask_gateway_server/backends/kubernetes/backend.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 
 from kubernetes_asyncio import client, config
 from kubernetes_asyncio.client.rest import ApiException
-from traitlets import Dict, Float, Unicode, default
+from traitlets import Dict, Float, Unicode, List, default
 from traitlets.config import LoggingConfigurable
 
 from ... import __version__ as VERSION
@@ -52,6 +52,12 @@ class KubeClusterConfig(ClusterConfig):
         "IfNotPresent",
         help="The image pull policy of the docker image specified in ``image``",
         config=True,
+    )
+
+    image_pull_secrets = List(
+        Unicode,
+        help="The pull secret(s) associated with the ``image``.",
+        config=True
     )
 
     # Kubernetes is a bit different in types/granularity of resource requests.

--- a/dask-gateway-server/dask_gateway_server/backends/kubernetes/backend.py
+++ b/dask-gateway-server/dask_gateway_server/backends/kubernetes/backend.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 
 from kubernetes_asyncio import client, config
 from kubernetes_asyncio.client.rest import ApiException
-from traitlets import Dict, Float, Unicode, List, default
+from traitlets import Dict, Float, List, Unicode, default
 from traitlets.config import LoggingConfigurable
 
 from ... import __version__ as VERSION
@@ -55,9 +55,7 @@ class KubeClusterConfig(ClusterConfig):
     )
 
     image_pull_secrets = List(
-        Unicode,
-        help="The pull secret(s) associated with the ``image``.",
-        config=True
+        Unicode, help="The pull secret(s) associated with the ``image``.", config=True
     )
 
     # Kubernetes is a bit different in types/granularity of resource requests.

--- a/resources/helm/dask-gateway/templates/gateway/configmap.yaml
+++ b/resources/helm/dask-gateway/templates/gateway/configmap.yaml
@@ -52,6 +52,8 @@ data:
             "%s:%s" % (image_name, image_tag) if image_tag else image_name
         )
 
+    c.KubeClusterConfig.imagePullSecrets = "{{ .Values.gateway.backend.imagePullSecrets }}"
+
     # Forward dask cluster configuration
     for field, prop_name in [
         # Scheduler config

--- a/resources/helm/dask-gateway/templates/gateway/configmap.yaml
+++ b/resources/helm/dask-gateway/templates/gateway/configmap.yaml
@@ -52,7 +52,7 @@ data:
             "%s:%s" % (image_name, image_tag) if image_tag else image_name
         )
 
-    c.KubeClusterConfig.imagePullSecrets = "{{ .Values.gateway.backend.imagePullSecrets }}"
+    c.KubeClusterConfig.image_pull_secrets = {{ .Values.gateway.backend.imagePullSecrets }}
 
     # Forward dask cluster configuration
     for field, prop_name in [

--- a/resources/helm/dask-gateway/values.schema.yaml
+++ b/resources/helm/dask-gateway/values.schema.yaml
@@ -239,6 +239,7 @@ properties:
         additionalProperties: false
         required:
           - image
+          - imagePullSecrets
           - scheduler
           - worker
         description: |
@@ -253,6 +254,7 @@ properties:
               Set a custom image name, tag, pullPolicy, or pullSecrets for Dask
               Cluster's scheduler and worker pods.
             properties: *image-properties
+          imagePullSecrets: *imagePullSecrets-spec
           namespace:
             type: [string, "null"]
             description: |

--- a/resources/helm/dask-gateway/values.yaml
+++ b/resources/helm/dask-gateway/values.yaml
@@ -87,6 +87,9 @@ gateway:
       tag: "set-by-chartpress"
       pullPolicy: IfNotPresent
 
+    # Image pull secrets for schedulers and worker pods
+    imagePullSecrets: []
+
     # The namespace to launch dask clusters in. If not specified, defaults to
     # the same namespace the gateway is running in.
     namespace:


### PR DESCRIPTION
This PR adds `imagePullSecrets` support for the `gateway.backend` (`dask-gateway`) image used by schedulers and workers.