### PR TITLE
Await rpc close in client

### DIFF
--- a/dask-gateway/dask_gateway/client.py
+++ b/dask-gateway/dask_gateway/client.py
@@ -1011,7 +1011,7 @@ class GatewayCluster:
         if self._watch_worker_status_task is not None:
             await cancel_task(self._watch_worker_status_task)
         if self.scheduler_comm is not None:
-            self.scheduler_comm.close_rpc()
+            await self.scheduler_comm.close_rpc()
         for client in list(self._clients):
             await client._close()
             self._clients.discard(client)


### PR DESCRIPTION
Missing await in client.py causes a warning when shutting down the cluster.

### Test
Tested on Ubuntu 22.04 with Python 3.10, dask-gateway==2022.6.1 and Slurm backend.

Test script:
```py
from dask_gateway import Gateway
from dask.distributed import Client, as_completed

import time

gateway = Gateway(...)

cluster = gateway.new_cluster()
cluster.scale(3)

try:
    client = Client(cluster)
    def calc(x):
        time.sleep(10 - x)
        return x 

    jobs = client.map(calc, range(10))
    for job in as_completed(jobs):
        print(job.result())
finally:
    cluster.shutdown()

```

### Actual output
The printed warning:
```
/lib/python3.10/site-packages/dask_gateway/client.py:1014: RuntimeWarning: coroutine 'rpc.close_rpc' was never awaited
  self.scheduler_comm.close_rpc()
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```

### After
No warning is displayed, rpc close coroutine is awaited.