### PR TITLE
feat: support watching a specific namespace only

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -145,7 +145,7 @@ jobs:
       #
       # ref: https://github.com/jupyterhub/action-k3s-helm/
       #
-      - uses: jupyterhub/action-k3s-helm@v2
+      - uses: jupyterhub/action-k3s-helm@v3
         with:
           k3s-channel: ${{ matrix.k3s-channel }}
           metrics-enabled: false

--- a/resources/helm/dask-gateway/templates/controller/deployment.yaml
+++ b/resources/helm/dask-gateway/templates/controller/deployment.yaml
@@ -55,6 +55,17 @@ spec:
           volumeMounts:
             - mountPath: /etc/dask-gateway/
               name: configmap
+          env:
+            - name: WATCH_NAMESPACE
+            {{- if .Values.runInClusterScope }}
+              value: ""
+            {{- else if .Values.watchNamespace }}
+              value: {{ .Values.watchNamespace | quote }}
+            {{- else }}
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            {{- end }}
           ports:
             - containerPort: 8000
               name: api

--- a/resources/helm/dask-gateway/templates/controller/rbac.yaml
+++ b/resources/helm/dask-gateway/templates/controller/rbac.yaml
@@ -9,7 +9,11 @@ metadata:
     {{- include "dask-gateway.labels" . | nindent 4 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.runInClusterScope }}
 kind: ClusterRole
+{{- else }}
+kind: Role
+{{- end }}
 metadata:
   name: {{ include "dask-gateway.controllerName" . }}
   labels:
@@ -31,7 +35,11 @@ rules:
     resources: ["secrets", "services"]
     verbs: ["create", "delete"]
 ---
+{{- if .Values.runInClusterScope }}
 kind: ClusterRoleBinding
+{{- else }}
+kind: RoleBinding
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "dask-gateway.controllerName" . }}
@@ -42,7 +50,11 @@ subjects:
     name: {{ include "dask-gateway.controllerName" . }}
     namespace: {{ .Release.Namespace }}
 roleRef:
+  {{- if .Values.runInClusterScope }}
   kind: ClusterRole
+  {{- else }}
+  kind: Role
+  {{- end }}
   name: {{ include "dask-gateway.controllerName" . }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/resources/helm/dask-gateway/templates/gateway/deployment.yaml
+++ b/resources/helm/dask-gateway/templates/gateway/deployment.yaml
@@ -54,6 +54,16 @@ spec:
             - mountPath: /etc/dask-gateway/
               name: configmap
           env:
+            - name: WATCH_NAMESPACE
+            {{- if .Values.runInClusterScope }}
+              value: ""
+            {{- else if .Values.watchNamespace }}
+              value: {{ .Values.watchNamespace | quote }}
+            {{- else }}
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            {{- end }}
             {{- if (eq .Values.gateway.auth.type "jupyterhub") }}
             - name: JUPYTERHUB_API_TOKEN
               valueFrom:

--- a/resources/helm/dask-gateway/templates/gateway/rbac.yaml
+++ b/resources/helm/dask-gateway/templates/gateway/rbac.yaml
@@ -8,7 +8,11 @@ metadata:
     {{- include "dask-gateway.labels" . | nindent 4 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.runInClusterScope }}
 kind: ClusterRole
+{{- else }}
+kind: Role
+{{- end }}
 metadata:
   name: {{ include "dask-gateway.apiName" . }}
   labels:
@@ -21,7 +25,11 @@ rules:
     resources: ["daskclusters"]
     verbs: ["*"]
 ---
+{{- if .Values.runInClusterScope }}
 kind: ClusterRoleBinding
+{{- else }}
+kind: RoleBinding
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "dask-gateway.apiName" . }}
@@ -32,7 +40,11 @@ subjects:
     name: {{ include "dask-gateway.apiName" . }}
     namespace: {{ .Release.Namespace }}
 roleRef:
+  {{- if .Values.runInClusterScope }}
   kind: ClusterRole
+  {{- else }}
+  kind: Role
+  {{- end }}
   name: {{ include "dask-gateway.apiName" . }}
   apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/resources/helm/dask-gateway/templates/traefik/deployment.yaml
+++ b/resources/helm/dask-gateway/templates/traefik/deployment.yaml
@@ -44,7 +44,9 @@ spec:
             - "--global.sendanonymoususage=False"
             - "--ping=true"
             - "--providers.kubernetescrd"
+            {{- if .Values.runInClusterScope }}
             - "--providers.kubernetescrd.allowCrossNamespace=true"
+            {{- end }}
             - '--providers.kubernetescrd.labelselector=gateway.dask.org/instance={{ include "dask-gateway.fullname" . }}'
             - "--providers.kubernetescrd.throttleduration=2"
             - "--log.level={{ .Values.traefik.loglevel }}"

--- a/resources/helm/dask-gateway/templates/traefik/rbac.yaml
+++ b/resources/helm/dask-gateway/templates/traefik/rbac.yaml
@@ -5,7 +5,11 @@ apiVersion: v1
 metadata:
   name: {{ include "dask-gateway.traefikName" . }}
 ---
+{{- if .Values.runInClusterScope }}
 kind: ClusterRole
+{{- else }}
+kind: Role
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "dask-gateway.traefikName" . }}
@@ -52,13 +56,21 @@ rules:
       - list
       - watch
 ---
+{{- if .Values.runInClusterScope }}
 kind: ClusterRoleBinding
+{{- else }}
+kind: RoleBinding
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "dask-gateway.traefikName" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
+  {{- if .Values.runInClusterScope }}
   kind: ClusterRole
+  {{- else }}
+  kind: Role
+  {{- end }}
   name: {{ include "dask-gateway.traefikName" . }}
 subjects:
 - kind: ServiceAccount

--- a/resources/helm/dask-gateway/values.schema.yaml
+++ b/resources/helm/dask-gateway/values.schema.yaml
@@ -26,6 +26,16 @@ properties:
     description: |
       See the description of fullnameOverride.
 
+  runInClusterScope:
+    type: boolean
+    description: |
+      Run the whole stack either at the cluster scope or at the namespace scope
+
+  watchNamespace:
+    type: [string, "null"]
+    description: |
+      Watch only a specific namespace
+
   gateway:
     type: object
     additionalProperties: false

--- a/resources/helm/dask-gateway/values.yaml
+++ b/resources/helm/dask-gateway/values.yaml
@@ -6,6 +6,16 @@ nameOverride: ""
 ##
 fullnameOverride: ""
 
+## Run the whole stack either at the cluster scope or at the namespace scope
+##
+runInClusterScope: true
+
+## Watch only a specific namespace
+## If runInClusterScope is false and watchNamespace is empty, it will watch the release namespace only
+## If runInClusterScope is true, it will watch all cluster namespaces
+##
+watchNamespace: ""
+
 # gateway nested config relates to the api Pod and the dask-gateway-server
 # running within it, the k8s Service exposing it, as well as the schedulers
 # (gateway.backend.scheduler) and workers gateway.backend.worker) created by the


### PR DESCRIPTION
# Proposal

Currently, dask-gateway fetches custom resources (DaskCluster, IngressRoute...) across all namespaces of the cluster.
This behavior is fine but if we want to use it strictly in a specific namespace, it is not possible with the state of the stack.
I have then thought of a way to adapt it without creating any breaking change with the following implementation.

# Implementation
- Add an environment variable `WATCH_NAMESPACE` that lets dask operators to specify a namespace so that all kubernetes commands that are launched within dask-gateway are targeted only on this specific namespace.
If this environment variable is not specified, it will start normally in cluster wide mode.
- Change the helm chart to add support for the environment variable `WATCH_NAMESPACE` thanks to the following fields:
  - `runInClusterScope`: Run the whole stack either at the cluster scope or at the namespace scope
  - `watchNamespace`: Watch only a specific namespace
- In namespaced mode, disable this traefik option: `"--providers.kubernetescrd.allowCrossNamespace=true"`
- Change the RBAC files to reflect the requirements of this new behavior:
  - Cluster wide config: ServiceAccount + ClusterRole + ClusterRoleBinding
  - Namespaced config: ServiceAccount + Role + RoleBinding

# Behind the scene
## Cluster wide
From the user and dask operator POV, it doesn't have any impact on the current behavior of dask-gateway which currently fetches kubernetes informations cluster wide (all namespaces).

## Namespaced
From the user and dask operator POV, it restricts them to the namespace where the stack is currently deployed.