### PR TITLE
ci: fix broken dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,8 +12,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
-      time: 05:00
+      time: "05:00"
       timezone: Etc/UTC
     labels:
       - ci
-      - dependencies


### PR DESCRIPTION
The time field has to be a string, and `05:00` according to YAML wasn't it appears.