### PR TITLE
Add public address to GatewayCluster when connecting to an existing cluster

### DIFF
--- a/dask-gateway/dask_gateway/client.py
+++ b/dask-gateway/dask_gateway/client.py
@@ -608,6 +608,7 @@ class Gateway:
             cluster_name,
             shutdown_on_close=shutdown_on_close,
             address=self.address,
+            public_address=self._public_address,
             proxy_address=self.proxy_address,
             auth=self.auth,
             asynchronous=self.asynchronous,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -304,6 +304,9 @@ async def test_dashboard_link_from_public_address():
                 for c in clusters:
                     assert c.dashboard_link.startswith("/services/dask-gateway")
 
+                cluster = await gateway.connect(cluster_name=cluster.name)
+                assert cluster.dashboard_link == sol
+
 
 async def test_create_cluster_with_GatewayCluster_constructor():
     async with temp_gateway() as g:


### PR DESCRIPTION
This pull request addresses an issue with the `public_address`, which is not taken into account in case you re-connect to an existing cluster. 

```python
gateway = Gateway(address="http://internal.local:8000",
                                  public_address="https://external.nginx/dask-gateway")
cluster = gateway.new_cluster()
cluster   # shows Dashboard: https://external.nginx/dask-gateway/clusters/...

cluster = gateway.connect(cluster_name=cluster.name)
cluster   # shows Dashboard: http://internal.local:8000/dask-gateway
```

After applying the pull request, the behaviour is changed to

```python
cluster = gateway.connect(cluster_name=cluster.name)
cluster   # shows Dashboard: https://external.nginx/dask-gateway/clusters/...
```

Thanks, for taking into account the changes.