### PR TITLE
Fix typo in SLURM backend.

### DIFF
--- a/dask-gateway-server/dask_gateway_server/backends/jobqueue/slurm.py
+++ b/dask-gateway-server/dask_gateway_server/backends/jobqueue/slurm.py
@@ -59,7 +59,7 @@ class SlurmBackend(JobQueueBackend):
         if cluster.config.partition:
             cmd.append("--partition=" + cluster.config.partition)
         if cluster.config.account:
-            cmd.account("--account=" + cluster.config.account)
+            cmd.append("--account=" + cluster.config.account)
         if cluster.config.qos:
             cmd.extend("--qos=" + cluster.config.qos)
 


### PR DESCRIPTION
This typo prevents a cluster being created when a SLURM account is set!