### PR TITLE
Helm chart: add gateway.backend.imagePullSecrets

### DIFF
--- a/dask-gateway-server/dask_gateway_server/backends/kubernetes/backend.py
+++ b/dask-gateway-server/dask_gateway_server/backends/kubernetes/backend.py
@@ -56,7 +56,12 @@ class KubeClusterConfig(ClusterConfig):
 
     image_pull_secrets = List(
         [],
-        help="Image pull secrets to access private registries",
+        help="""
+        Image pull secrets to access private registries.
+        
+        Should be a list of dictionaries with a single key called ``name`` to
+        match the k8s native syntax.
+        """,
         config=True,
     )
 

--- a/dask-gateway-server/dask_gateway_server/backends/kubernetes/backend.py
+++ b/dask-gateway-server/dask_gateway_server/backends/kubernetes/backend.py
@@ -6,7 +6,7 @@ from collections import defaultdict
 
 from kubernetes_asyncio import client, config
 from kubernetes_asyncio.client.rest import ApiException
-from traitlets import Dict, Float, Unicode, default
+from traitlets import Dict, Float, List, Unicode, default
 from traitlets.config import LoggingConfigurable
 
 from ... import __version__ as VERSION
@@ -51,6 +51,12 @@ class KubeClusterConfig(ClusterConfig):
     image_pull_policy = Unicode(
         "IfNotPresent",
         help="The image pull policy of the docker image specified in ``image``",
+        config=True,
+    )
+
+    image_pull_secrets = List(
+        [],
+        help="Image pull secrets to access private registries",
         config=True,
     )
 

--- a/dask-gateway-server/dask_gateway_server/backends/kubernetes/backend.py
+++ b/dask-gateway-server/dask_gateway_server/backends/kubernetes/backend.py
@@ -58,7 +58,7 @@ class KubeClusterConfig(ClusterConfig):
         [],
         help="""
         Image pull secrets to access private registries.
-        
+
         Should be a list of dictionaries with a single key called ``name`` to
         match the k8s native syntax.
         """,

--- a/dask-gateway-server/dask_gateway_server/backends/kubernetes/controller.py
+++ b/dask-gateway-server/dask_gateway_server/backends/kubernetes/controller.py
@@ -1175,9 +1175,8 @@ class KubeController(KubeBackendAndControllerMixin, Application):
             },
         }
 
-        pod["spec"]["imagePullSecrets"] = []
-        for image_pull_secret in config.image_pull_secrets:
-            pod["spec"]["imagePullSecrets"].append({"name": image_pull_secret})
+        if config.image_pull_secrets:
+            pod["spec"]["imagePullSecrets"] = config.image_pull_secrets
 
         if extra_pod_config:
             pod["spec"] = merge_json_objects(pod["spec"], extra_pod_config)

--- a/dask-gateway-server/dask_gateway_server/backends/kubernetes/controller.py
+++ b/dask-gateway-server/dask_gateway_server/backends/kubernetes/controller.py
@@ -1175,6 +1175,10 @@ class KubeController(KubeBackendAndControllerMixin, Application):
             },
         }
 
+        pod["spec"]["imagePullSecrets"] = []
+        for image_pull_secret in config.image_pull_secrets:
+            pod["spec"]["imagePullSecrets"].append({"name": image_pull_secret})
+
         if extra_pod_config:
             pod["spec"] = merge_json_objects(pod["spec"], extra_pod_config)
 

--- a/resources/helm/dask-gateway/templates/gateway/configmap.yaml
+++ b/resources/helm/dask-gateway/templates/gateway/configmap.yaml
@@ -51,6 +51,7 @@ data:
         c.KubeClusterConfig.image = (
             "%s:%s" % (image_name, image_tag) if image_tag else image_name
         )
+        c.KubeClusterConfig.image_pull_secrets = get_property("gateway.backend.imagePullSecrets")
 
     # Forward dask cluster configuration
     for field, prop_name in [

--- a/resources/helm/dask-gateway/values.schema.yaml
+++ b/resources/helm/dask-gateway/values.schema.yaml
@@ -251,6 +251,7 @@ properties:
           - image
           - scheduler
           - worker
+          - imagePullSecrets
         description: |
           `backend` nested configuration relates to the scheduler and worker
           resources created for DaskCluster k8s resources by the controller.
@@ -263,6 +264,7 @@ properties:
               Set a custom image name, tag, pullPolicy, or pullSecrets for Dask
               Cluster's scheduler and worker pods.
             properties: *image-properties
+          imagePullSecrets: *imagePullSecrets-spec
           namespace:
             type: [string, "null"]
             description: |

--- a/resources/helm/dask-gateway/values.yaml
+++ b/resources/helm/dask-gateway/values.yaml
@@ -107,6 +107,9 @@ gateway:
       tag: "set-by-chartpress"
       pullPolicy: IfNotPresent
 
+    # Image pull secrets for backend pod
+    imagePullSecrets: []
+
     # The namespace to launch dask clusters in. If not specified, defaults to
     # the same namespace the gateway is running in.
     namespace:

--- a/resources/helm/dask-gateway/values.yaml
+++ b/resources/helm/dask-gateway/values.yaml
@@ -107,7 +107,7 @@ gateway:
       tag: "set-by-chartpress"
       pullPolicy: IfNotPresent
 
-    # Image pull secrets for backend pod
+    # Image pull secrets for a dask cluster's scheduler and worker pods
     imagePullSecrets: []
 
     # The namespace to launch dask clusters in. If not specified, defaults to


### PR DESCRIPTION
# Proposal

Currently, dask-gateway retrieves images that are hosted on public registries.
This behavior is fine but if we want to use private registries, it is only possible through `worker_extra_pod_config` and `scheduler_extra_pod_config`.
I have then tought of a way to implement it properly without introducing any breaking change.

# Implementation
- Add a `KubeClusterConfig` configuration field called `image_pull_secrets` that lets dask scheduler and worker pods to pull images from private registries.
- Change the helm chart to add support for the configuration field called `image_pull_secrets` thanks to the following field:
  - `imagePullSecrets`: Image pull secrets to access private registries

# Behind the scene
From the user and dask operator POV, it doesn't have any impact on the current behavior of dask-gateway.

---

- EDIT by consideRatio: closes #583 as this is a duplicate PR.
- EDIT by consideRatio: closes #584