### PR TITLE
Add AttributeError exception for _ipython_display_

### DIFF
--- a/dask-gateway/dask_gateway/client.py
+++ b/dask-gateway/dask_gateway/client.py
@@ -1222,7 +1222,11 @@ class GatewayCluster:
     def _ipython_display_(self, **kwargs):
         widget = self._widget()
         if widget is not None:
-            return widget._ipython_display_(**kwargs)
+            # ipywidgets renamed the _ipython_display_ method in 8.x
+            try:
+                return widget._ipython_display_(**kwargs)
+            except AttributeError:
+                return widget._repr_mimebundle_(**kwargs)
         else:
             from IPython.display import display
 

--- a/dask-gateway/dask_gateway/options.py
+++ b/dask-gateway/dask_gateway/options.py
@@ -74,7 +74,11 @@ class Options(MutableMapping):
     def _ipython_display_(self, **kwargs):
         widget = self._widget()
         if widget is not None:
-            return widget._ipython_display_(**kwargs)
+            # ipywidgets renamed the _ipython_display_ method in 8.x
+            try:
+                return widget._ipython_display_(**kwargs)
+            except AttributeError:
+                return widget._repr_mimebundle_(**kwargs)
         from IPython.lib.pretty import pprint
 
         pprint(self)


### PR DESCRIPTION
Fixes #607 

After `ipywidgets` released their `8.0.0` version the `_ipython_display_` method was renamed to `_repr_mimebundle_`, this handles the method's incompatibility by using an AttributeError exception.