### PR TITLE
Simplified integration with namespace local JupyterHub Helm charts

### DIFF
--- a/resources/helm/dask-gateway/templates/gateway/deployment.yaml
+++ b/resources/helm/dask-gateway/templates/gateway/deployment.yaml
@@ -58,8 +58,13 @@ spec:
             - name: JUPYTERHUB_API_TOKEN
               valueFrom:
                 secretKeyRef:
+                  {{- if .Values.gateway.auth.jupyterhub.apiToken }}
                   name: {{ include "dask-gateway.apiName" . }}
                   key: jupyterhub-api-token
+                  {{- else }}
+                  name: "{{ .Values.gateway.auth.jupyterhub.apiTokenFromSecretName }}"
+                  key: "{{ .Values.gateway.auth.jupyterhub.apiTokenFromSecretKey }}"
+                  {{- end }}
             {{- end }}
           ports:
             - containerPort: 8000

--- a/resources/helm/dask-gateway/templates/gateway/secret.yaml
+++ b/resources/helm/dask-gateway/templates/gateway/secret.yaml
@@ -1,4 +1,4 @@
-{{- if eq .Values.gateway.auth.type "jupyterhub" -}}
+{{- if and (eq .Values.gateway.auth.type "jupyterhub") .Values.gateway.auth.jupyterhub.apiToken -}}
 kind: Secret
 apiVersion: v1
 metadata:
@@ -7,5 +7,5 @@ metadata:
     {{- include "dask-gateway.labels" . | nindent 4 }}
 type: Opaque
 data:
-  jupyterhub-api-token: {{ required "gateway.auth.jupyterhub.apiToken must be defined when using jupyterhub auth" .Values.gateway.auth.jupyterhub.apiToken | b64enc | quote }}
+  jupyterhub-api-token: {{ .Values.gateway.auth.jupyterhub.apiToken | b64enc | quote }}
 {{- end }}

--- a/resources/helm/dask-gateway/values.schema.yaml
+++ b/resources/helm/dask-gateway/values.schema.yaml
@@ -225,6 +225,19 @@ properties:
                 description: |
                   A JupyterHub api token for dask-gateway to use. See
                   https://gateway.dask.org/install-kube.html#authenticating-with-jupyterhub.
+              apiTokenFromSecretName:
+                type: [string]
+                description: |
+                  A k8s Secret in the same namespace as dask-gateway where we
+                  can look for a JupyterHub api token for dask-gateway to use. See
+                  https://gateway.dask.org/install-kube.html#authenticating-with-jupyterhub.
+              apiTokenFromSecretKey:
+                type: [string]
+                description: |
+                  The name of a key in a k8s Secret named by
+                  `apiTokenFromSecretName` holding the value of a JupyterHub api
+                  token for dask-gateway to use. See
+                  https://gateway.dask.org/install-kube.html#authenticating-with-jupyterhub.
               apiUrl:
                 type: [string, "null"]
                 description: |

--- a/resources/helm/dask-gateway/values.yaml
+++ b/resources/helm/dask-gateway/values.yaml
@@ -58,6 +58,16 @@ gateway:
       # https://gateway.dask.org/install-kube.html#authenticating-with-jupyterhub.
       apiToken:
 
+      # The JupyterHub Helm chart will automatically generate a token for a
+      # registered service. If you don't specify an apiToken explicitly as
+      # required in dask-gateway version <=2022.6.1, the dask-gateway Helm chart
+      # will try to look for a token from a k8s Secret created by the JupyterHub
+      # Helm chart in the same namespace. A failure to find this k8s Secret and
+      # key will cause a MountFailure for when the api-dask-gateway pod is
+      # starting.
+      apiTokenFromSecretName: hub
+      apiTokenFromSecretKey: hub.services.dask-gateway.apiToken
+
       # JupyterHub's api url. Inferred from JupyterHub's service name if running
       # in the same namespace.
       apiUrl:


### PR DESCRIPTION
## Summary

Closes #473. The idea is to enable users installing both the dask-gateway chart and jupyterhub chart to not provide any api-token credential for dask-gateway/juyterhub to trust each other, but instead rely on a generated api-token persisted in a k8s Secret.

The implementation plan in #473 was the following:

> ### Implementation idea
> 1. Allow a k8s Secret name and key be configurable to mount the JupyterHub API token from a custom k8s Secret with a given key.
> 2. Make the creation of the dask-gateway managed k8s Secret be conditional of not providing a custom k8s Secret name / key.
> 3. Update the values schema with these settings

This PR follows that plan quite well, but provides a default for the k8s Secret name and Key config and relies on them by default unless the previously required `apiToken` is specified. This PR also updates the documentation under the topic of installing the dask-gateway helm chart and autenticating against a JupyterHub Helm chart installation.

## Added chart config in values.yaml

```yaml
gateway:
  auth:
    jupyterhub:
      # The JupyterHub Helm chart will automatically generate a token for a
      # registered service. If you don't specify an apiToken explicitly as
      # required in dask-gateway version <=2022.6.1, the dask-gateway Helm chart
      # will try to look for a token from a k8s Secret created by the JupyterHub
      # Helm chart in the same namespace. A failure to find this k8s Secret and
      # key will cause a MountFailure for when the api-dask-gateway pod is
      # starting.
      apiTokenFromSecretName: hub
      apiTokenFromSecretKey: hub.services.dask-gateway.apiToken
```

The schema file is also updated to reflect this new configuration.

## Successfully tested

I've tested this on the hub.jupytearth.org deployment of a dask-gateway deployed next to a jupyterhub.

## How dask/helm-chart's daskhub would adjust with this

[Steps relating to generating and configuring an api token](https://github.com/dask/helm-chart/blob/a9f94ca7a040b4a42c0554ebb4f9bf55c2ce7ec7/daskhub/.frigate#L26-L56) could be simplied. This would be an example of the configuration to have, without secret credentials involved.

```yaml
jupyterhub:
  hub:
    services:
      dask-gateway:
        display: false

dask-gateway:
  gateway:
    auth:
      type: jupyterhub
```