### PR TITLE
Reduce RBAC privileges for single namespace deployment

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -128,8 +128,13 @@ jobs:
         include:
           - k3s-channel: v1.20
             upgrade-from: "0.9.0"
+            dask-namespace: "default"
           - k3s-channel: stable
+            dask-namespace: "default"
+          - k3s-channel: stable
+            dask-namespace: "additional"
           - k3s-channel: latest
+            dask-namespace: "default"
 
     steps:
       - uses: actions/checkout@v3
@@ -172,6 +177,10 @@ jobs:
               --include-crds \
               --values=resources/helm/testing/chart-install-values.yaml
 
+      - if: matrix.dask-namespace == 'additional'
+        run: |
+          kubectl create namespace additional
+
       - name: helm install previous version ${{ matrix.upgrade-from }}
         if: matrix.upgrade-from != ''
         run: |
@@ -209,6 +218,7 @@ jobs:
               resources/helm/dask-gateway \
               --install \
               --values=resources/helm/testing/chart-install-values.yaml \
+              --set gateway.backend.namespace=${{ matrix.dask-namespace }} \
               --wait \
               --timeout 1m0s
 

--- a/resources/helm/dask-gateway/templates/controller/rbac.yaml
+++ b/resources/helm/dask-gateway/templates/controller/rbac.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.controller.enabled -}}
 {{- if .Values.rbac.enabled -}}
 {{- if not .Values.rbac.controller.serviceAccountName -}}
+{{- $multiNamespace := default false (and .Values.gateway.backend.namespace (ne .Release.Namespace .Values.gateway.backend.namespace)) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -12,6 +13,49 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "dask-gateway.controllerName" . }}
+  labels:
+    {{- include "dask-gateway.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["gateway.dask.org"]
+    resources: ["daskclusters", "daskclusters/status"]
+    verbs: {{ ternary "[\"*\"]" "[\"get\", \"list\", \"watch\"]" $multiNamespace }}
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch" {{- if $multiNamespace }}, "create", "delete"{{ end -}} ]
+  - apiGroups: [""]
+    resources: ["endpoints"]
+    verbs: ["get", "list", "watch"]
+{{- if $multiNamespace }}
+  - apiGroups: [""]
+    resources: ["secrets", "services"]
+    verbs: ["create", "delete"]
+  - apiGroups: ["traefik.containo.us"]
+    resources: ["ingressroutes", "ingressroutetcps"]
+    verbs: ["get", "create", "delete"]
+{{- end }}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "dask-gateway.controllerName" . }}
+  labels:
+    {{- include "dask-gateway.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "dask-gateway.controllerName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "dask-gateway.controllerName" . }}
+  apiGroup: rbac.authorization.k8s.io
+
+---
+{{- if not $multiNamespace }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "dask-gateway.controllerName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "dask-gateway.labels" . | nindent 4 }}
 rules:
@@ -31,10 +75,11 @@ rules:
     resources: ["secrets", "services"]
     verbs: ["create", "delete"]
 ---
-kind: ClusterRoleBinding
+kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "dask-gateway.controllerName" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "dask-gateway.labels" . | nindent 4 }}
 subjects:
@@ -42,9 +87,11 @@ subjects:
     name: {{ include "dask-gateway.controllerName" . }}
     namespace: {{ .Release.Namespace }}
 roleRef:
-  kind: ClusterRole
+  kind: Role
   name: {{ include "dask-gateway.controllerName" . }}
   apiGroup: rbac.authorization.k8s.io
+
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/resources/helm/dask-gateway/templates/gateway/rbac.yaml
+++ b/resources/helm/dask-gateway/templates/gateway/rbac.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.rbac.enabled -}}
 {{- if not .Values.rbac.gateway.serviceAccountName -}}
+{{- $multiNamespace := default false (and .Values.gateway.backend.namespace (ne .Release.Namespace .Values.gateway.backend.namespace)) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -14,12 +15,14 @@ metadata:
   labels:
     {{- include "dask-gateway.labels" . | nindent 4 }}
 rules:
+{{- if $multiNamespace }}
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get"]
+{{- end }}
   - apiGroups: ["gateway.dask.org"]
     resources: ["daskclusters"]
-    verbs: ["*"]
+    verbs: {{ ternary "[\"*\"]" "[\"get\", \"list\", \"watch\"]" $multiNamespace }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -35,5 +38,35 @@ roleRef:
   kind: ClusterRole
   name: {{ include "dask-gateway.apiName" . }}
   apiGroup: rbac.authorization.k8s.io
+
+{{- if not $multiNamespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "dask-gateway.apiName" . }}
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get"]
+  - apiGroups: ["gateway.dask.org"]
+    resources: ["daskclusters"]
+    verbs: ["*"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "dask-gateway.apiName" . }}
+  namespace: {{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "dask-gateway.apiName" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "dask-gateway.apiName" . }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
 {{- end }}
 {{- end }}

--- a/resources/helm/dask-gateway/templates/traefik/deployment.yaml
+++ b/resources/helm/dask-gateway/templates/traefik/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $multiNamespace := default false (and .Values.gateway.backend.namespace (ne .Release.Namespace .Values.gateway.backend.namespace)) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -60,6 +61,9 @@ spec:
             {{- if .Values.traefik.dashboard }}
             - "--api.dashboard=true"
             - "--api.insecure=true"
+            {{- end }}
+            {{- if not $multiNamespace }}
+            - "--providers.kubernetescrd.namespaces={{ .Release.Namespace }}"
             {{- end }}
             {{- range .Values.traefik.additionalArguments }}
             - {{ . | quote }}

--- a/resources/helm/dask-gateway/templates/traefik/rbac.yaml
+++ b/resources/helm/dask-gateway/templates/traefik/rbac.yaml
@@ -1,11 +1,12 @@
 {{- if .Values.rbac.enabled -}}
 {{- if not .Values.rbac.traefik.serviceAccountName -}}
+{{- $multiNamespace := default false (and .Values.gateway.backend.namespace (ne .Release.Namespace .Values.gateway.backend.namespace)) }}
 kind: ServiceAccount
 apiVersion: v1
 metadata:
   name: {{ include "dask-gateway.traefikName" . }}
 ---
-kind: ClusterRole
+kind: {{ ternary "ClusterRole" "Role" $multiNamespace }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "dask-gateway.traefikName" . }}
@@ -52,13 +53,13 @@ rules:
       - list
       - watch
 ---
-kind: ClusterRoleBinding
+kind: {{ ternary "ClusterRoleBinding" "RoleBinding" $multiNamespace }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "dask-gateway.traefikName" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
+  kind: {{ ternary "ClusterRole" "Role" $multiNamespace }}
   name: {{ include "dask-gateway.traefikName" . }}
 subjects:
 - kind: ServiceAccount


### PR DESCRIPTION
## Overview

The dask-gateway helm chart deploys three microservices: gateway, controller, traefik into a single namespace.   

When a user requests a new dask cluster, a number of Kubernetes custom resource definition objects are created, as well as pods for dask-scheduler and dask-workers.   By default, these are deployed into the same namespace as the microservices, but can be configured to deploy to a separate namespace via the `gateway.backend.namespace` helm value.

For the same-namespace deployment, the chart creates cluster-wide permissions that are unnecessarily permissive.  This PR checks if the user has set `gateway.backend.namespace` to a different namespace.  In the case of a single-namespace deployment, it moves `ClusterRole` permissions to namespaced `Role` permissions
whenever possible.   It also adds an option to the traefik chart so that it only listens on a single namespace.

In addition, for the single-namespace deployment, the code itself is also unnecessarily broad - for example, it performs cluster-wide queries for `daskcluster` when it should restrict itself to namespaced queries.  This PR does *not* address this, but https://github.com/dask/dask-gateway/pull/594 does.

#### What I wrote previously: 

If we are deploying into a single namespace (gateway.backend.Namespace is either null or the same as the release namespace), move as many privileges as possible from cluster-wide to namespaced ones.

This is one possible mitigation to the security concerns discussed in #250.