### PR TITLE
Extend integration tests to multi-namespace deployment

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -128,8 +128,13 @@ jobs:
         include:
           - k3s-channel: v1.20
             upgrade-from: "0.9.0"
+            dask-namespace: default
           - k3s-channel: stable
+            dask-namespace: default
+          - k3s-channel: stable
+            dask-namespace: scheduler
           - k3s-channel: latest
+            dask-namespace: default
 
     steps:
       - uses: actions/checkout@v3
@@ -172,6 +177,10 @@ jobs:
               --include-crds \
               --values=resources/helm/testing/chart-install-values.yaml
 
+      - if: matrix.dask-namespace != 'default'
+        run: |
+             kubectl create namespace ${{ matrix.dask-namespace }} || true
+
       - name: helm install previous version ${{ matrix.upgrade-from }}
         if: matrix.upgrade-from != ''
         run: |
@@ -209,6 +218,7 @@ jobs:
               resources/helm/dask-gateway \
               --install \
               --values=resources/helm/testing/chart-install-values.yaml \
+              --set gateway.backend.namespace=${{ matrix.dask-namespace }} \
               --wait \
               --timeout 1m0s
 
@@ -216,6 +226,7 @@ jobs:
         run: |
           TEST_DASK_GATEWAY_KUBE=true \
           TEST_DASK_GATEWAY_KUBE_ADDRESS=http://localhost:30200/services/dask-gateway/ \
+          TEST_DASK_GATEWAY_KUBE_NAMESPACE=${{ matrix.dask-namespace }} \
           pytest -v tests/kubernetes
 
       # ref: https://github.com/jupyterhub/action-k8s-namespace-report


### PR DESCRIPTION
This extends the kubernetes integration test coverage to handle the case when the scheduler/worker namespace (configured via `gateway.backend.namespace`) is different than the one for gateway/controller/traefik.