### PR TITLE
Fix failure to build and publish arm64 images

### DIFF
--- a/.github/workflows/build-publish-helm-chart.yaml
+++ b/.github/workflows/build-publish-helm-chart.yaml
@@ -64,4 +64,7 @@ jobs:
           #
           GITHUB_ACTOR: ""
           GITHUB_TOKEN: "${{ secrets.dask_bot_token }}"
+          # DOCKER_BUILDKIT is required for building images with --mount flags,
+          # as used in dask-gateway/Dockerfile.
+          DOCKER_BUILDKIT: "1"
         run: continuous_integration/kubernetes/build-publish-helm-chart.sh

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -189,6 +189,10 @@ jobs:
               --timeout 1m0s
 
       - working-directory: resources/helm
+        env:
+          # DOCKER_BUILDKIT is required for building images with --mount flags,
+          # as used in dask-gateway/Dockerfile.
+          DOCKER_BUILDKIT: "1"
         run: chartpress
 
       # If the Helm chart's CRDs have changed, helm won't upgrade them when

--- a/dask-gateway/Dockerfile
+++ b/dask-gateway/Dockerfile
@@ -11,7 +11,36 @@
 #
 # See https://gateway.dask.org/install-kube.html#using-a-custom-image.
 #
-FROM python:3.10-slim-bullseye
+
+
+# The build stage
+# ---------------
+# This stage is building Python wheels for use in later stages by using a base
+# image that has more pre-requisites to do so, such as a C++ compiler.
+#
+# psutils, a dependency of distributed, is currently the sole reason we have to
+# have this build stage.
+#
+FROM python:3.10-bullseye as build-stage
+
+# Build wheels
+#
+# We set pip's cache directory and expose it across build stages via an
+# ephemeral docker cache (--mount=type=cache,target=${PIP_CACHE_DIR}).
+#
+COPY . /opt/dask-gateway
+ARG PIP_CACHE_DIR=/tmp/pip-cache
+RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
+    pip install build \
+ && pip wheel \
+        --wheel-dir=/tmp/wheels \
+        -r /opt/dask-gateway/Dockerfile.requirements.txt
+
+
+# The final stage
+# ---------------
+#
+FROM python:3.10-slim-bullseye as slim-stage
 
 # Set labels based on the Open Containers Initiative (OCI):
 # https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys
@@ -34,7 +63,11 @@ WORKDIR /home/dask/
 
 # Install dask-gateway
 COPY --chown=dask:dask . /opt/dask-gateway
-RUN pip install --no-cache-dir \
+ARG PIP_CACHE_DIR=/tmp/pip-cache
+RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
+    --mount=type=cache,from=build-stage,source=/tmp/wheels,target=/tmp/wheels \
+    pip install \
+        --find-links=/tmp/wheels/ \
         -r /opt/dask-gateway/Dockerfile.requirements.txt
 
 # Only set ENTRYPOINT, CMD is configured at runtime by dask-gateway-server

--- a/resources/helm/chartpress.yaml
+++ b/resources/helm/chartpress.yaml
@@ -27,11 +27,6 @@ charts:
         contextPath: ../../dask-gateway
         valuesPath:
           - gateway.backend.image
-        # FIXME: psutils, a dependency of distributed, currently doesn't have wheels
-        #        for arm64 and requires `gcc` and `python3-dev` of a compatible version
-        #        of python (python 3.9 for debian bullseye).
-        skipPlatforms:
-          - linux/arm64
       # Used for the api and controller pods
       dask-gateway-server:
         imageName: ghcr.io/dask/dask-gateway-server


### PR DESCRIPTION
## Summary

- A bugfix of dask-gateway-server image for arm64 wasn't built or published
- A new feature of providing the dask-gateway image (demo for scheduler/workers) for arm64 as well. Now the entire helm chart is arm64 compatible.
  - This involved adding a build stage where compilers etc were available to build wheels (psutils specifically), and then using them in the final stage of the Dockerfile. Note there is a quite cool trick involved here, were we avoid a COPY operation, but instead using `--mount` for the `RUN` command, making things from the previous stage accessible without creating another layer that takes up space in the final image.

## Background

There is a [bug in `chartpress`](https://github.com/jupyterhub/chartpress/pull/193) making us fail to build and publish the arm64 variant of the dask-gateway-server image. This PR makes us avoid that bug by making the dask-gateway image also support arm64.

- Closes #629