### PR TITLE
Test against golang 1.19, latest slurm, latest hadoop

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,11 +56,13 @@ jobs:
           #   that would be fine.
           #
           - python-version: "3.8"
-            go-version: "1.16"
-          - python-version: "3.9"
-            go-version: "1.17"
-          - python-version: "3.10"
             go-version: "1.18"
+          - python-version: "3.9"
+            go-version: "1.18"
+          - python-version: "3.10"
+            go-version: "1.19"
+          - python-version: "3.11"
+            go-version: "1.19"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -61,10 +61,9 @@ jobs:
             go-version: "1.18"
           - python-version: "3.10"
             go-version: "1.19"
-          # FIXME: As of 2022-11-07, our dask-gateway tests fails with Python
-          #        3.11.
-          - python-version: "3.11"
-            go-version: "1.19"
+          # FIXME: See https://github.com/dask/dask-gateway/issues/638
+          # - python-version: "3.11"
+          #   go-version: "1.19"
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -61,6 +61,8 @@ jobs:
             go-version: "1.18"
           - python-version: "3.10"
             go-version: "1.19"
+          # FIXME: As of 2022-11-07, our dask-gateway tests fails with Python
+          #        3.11.
           - python-version: "3.11"
             go-version: "1.19"
 

--- a/continuous_integration/docker/base/Dockerfile
+++ b/continuous_integration/docker/base/Dockerfile
@@ -53,7 +53,7 @@ RUN yum install -y bzip2 \
  && curl -sL https://micromamba.snakepit.net/api/micromamba/linux-64/latest \
   | tar --extract --verbose --bzip2 bin/micromamba --strip-components=1 \
  && ./micromamba install \
-    --channel conda-forge \
+    --channel=conda-forge \
     --root-prefix="/opt/python" \
     --prefix="/opt/python" \
           python="${python_version}" \

--- a/continuous_integration/docker/base/Dockerfile
+++ b/continuous_integration/docker/base/Dockerfile
@@ -7,8 +7,8 @@
 #
 FROM centos:7
 
-ARG python_version="3.10"
-ARG go_version="1.18"
+ARG python_version="3.11"
+ARG go_version="1.19"
 
 # Set labels based on the Open Containers Initiative (OCI):
 # https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys

--- a/continuous_integration/docker/base/Dockerfile
+++ b/continuous_integration/docker/base/Dockerfile
@@ -11,7 +11,7 @@ FROM centos:7
 #        need to built it, but also then have gcc available during that time.
 #        Due to this, our test suite is broken.
 #
-ARG python_version="3.11"
+ARG python_version="3.10"
 ARG go_version="1.19"
 
 # Set labels based on the Open Containers Initiative (OCI):

--- a/continuous_integration/docker/base/Dockerfile
+++ b/continuous_integration/docker/base/Dockerfile
@@ -7,6 +7,10 @@
 #
 FROM centos:7
 
+# FIXME: As of 2022-11-07, pykerberos didn't have a wheel available making us
+#        need to built it, but also then have gcc available during that time.
+#        Due to this, our test suite is broken.
+#
 ARG python_version="3.11"
 ARG go_version="1.19"
 

--- a/continuous_integration/docker/hadoop/Dockerfile
+++ b/continuous_integration/docker/hadoop/Dockerfile
@@ -47,8 +47,8 @@ ENV JAVA_HOME /usr/lib/jvm/jre-openjdk
 #    setgid bits for this directory so that folders created in it become owned
 #    by root:hadoop as well.
 #
-RUN INSTALL_HADOOP_VERSION=3.3.2 \
- && curl -sL /tmp/hadoop.tar.gz https://dlcdn.apache.org/hadoop/common/stable/hadoop-${INSTALL_HADOOP_VERSION}.tar.gz \
+RUN INSTALL_HADOOP_VERSION=3.3.4 \
+ && curl -sL /tmp/hadoop.tar.gz https://dlcdn.apache.org/hadoop/common/hadoop-${INSTALL_HADOOP_VERSION}/hadoop-${INSTALL_HADOOP_VERSION}.tar.gz \
   | tar -xvz --directory /opt \
  && mv /opt/hadoop-* /opt/hadoop \
  && chown -R root:hadoop /opt/hadoop \
@@ -80,8 +80,13 @@ ENV PATH=/opt/hadoop/sbin:/opt/hadoop/bin:$PATH
 #    these folders later and want them to have root:hadoop ownership for
 #    readability, we "chmod ug+s" as well on the folder.
 #
+#    We workaround this error for example:
+#
+#        File /etc/hadoop/conf.kerberos must not be world or group writable, but is 6775
+#
 COPY --chown=root:hadoop ./files/etc/hadoop /etc/hadoop/
 RUN chmod -R ug+s /etc/hadoop/
+RUN chmod -R go-w /etc/hadoop/conf.kerberos
 #
 # 7. Copy our setup script and run it
 #

--- a/continuous_integration/docker/hadoop/_install.sh
+++ b/continuous_integration/docker/hadoop/_install.sh
@@ -5,7 +5,7 @@ cd /working
 
 # pykerberos needs to compile c++ code that depends on system libraries, by
 # installing it from conda-forge, we avoid such hassle.
-mamba install pykerberos
+mamba install -c conda-forge pykerberos
 
 # This installs everything else we need for tests
 pip install -r tests/requirements.txt

--- a/continuous_integration/docker/slurm/Dockerfile
+++ b/continuous_integration/docker/slurm/Dockerfile
@@ -19,7 +19,7 @@ ENV TEST_DASK_GATEWAY_SLURM true
 #    Slurm versions:      https://download.schedmd.com/slurm/
 #    Slurm release notes: https://github.com/SchedMD/slurm/blame/HEAD/RELEASE_NOTES
 #
-RUN INSTALL_SLURM_VERSION=21.08.6 \
+RUN INSTALL_SLURM_VERSION=22.05.5 \
  && yum install -y \
         # required to install supervisor (and more?)
         epel-release \

--- a/continuous_integration/docker/slurm/files/etc/slurm/cgroup.conf
+++ b/continuous_integration/docker/slurm/files/etc/slurm/cgroup.conf
@@ -1,0 +1,13 @@
+# Configuration reference: https://slurm.schedmd.com/cgroup.conf.html
+#
+# This file was added as a workaround added when upgrading to from surm
+# 2021.08.6 to 22.05.5, where slurmd failed to start with an error message
+# logged in /var/log/slurm/slurmd.log saying:
+#
+#   error: Couldn't find the specified plugin name for cgroup/v2 looking at all files
+#   error: cannot find cgroup plugin for cgroup/v2
+#   error: cannot create cgroup context for cgroup/v2
+#   error: Unable to initialize cgroup plugin
+#   error: slurmd initialization failed
+#
+CgroupPlugin=cgroup/v1

--- a/dask-gateway/setup.py
+++ b/dask-gateway/setup.py
@@ -36,7 +36,6 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
     ],
     keywords="dask hadoop kubernetes HPC distributed cluster",
     description="A client library for interacting with a dask-gateway server",

--- a/dask-gateway/setup.py
+++ b/dask-gateway/setup.py
@@ -26,7 +26,7 @@ setup(
     maintainer_email="jcristharif@gmail.com",
     license="BSD",
     classifiers=[
-        "Development Status :: 4 - Beta",
+        "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: BSD License",
         "Intended Audience :: Developers",
         "Intended Audience :: Science/Research",
@@ -36,6 +36,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     keywords="dask hadoop kubernetes HPC distributed cluster",
     description="A client library for interacting with a dask-gateway server",


### PR DESCRIPTION
Updates our tests a bit, including a rebuild of the ci test images for slurm/pbs/hadoop with updates to slurm/hadoop but not PBS as that would require us to leave centos:7 as a base image or build PBS from source.

I meant to update test suite to test against Python 3.11, but ended up failing to do so because dependencies doesn't support it yet. This is tracked in #638.