### PR TITLE
ci: help hadoop/pbs tests become robuster by awaiting startup

### DIFF
--- a/continuous_integration/docker/README.md
+++ b/continuous_integration/docker/README.md
@@ -120,7 +120,7 @@ cd ./hadoop
 ./print_logs.sh
 
 # cleanup after running tests
-docker stop --timeout=0 hadoop
+docker stop --time=0 hadoop
 ```
 
 ## Debugging
@@ -189,7 +189,7 @@ If something seems wrong, dig deeper.
 ```shell
 # Start a container and inspect the container from a shell if something doesn't
 # start correctly.
-docker stop hadoop --timeout=0
+docker stop --time=0 hadoop
 docker run --name hadoop --hostname master.example.com --detach --rm ghcr.io/dask/dask-gateway-ci-hadoop
 docker exec -it hadoop bash
 

--- a/continuous_integration/docker/hadoop/start.sh
+++ b/continuous_integration/docker/hadoop/start.sh
@@ -13,3 +13,35 @@ docker run --rm -d \
     -p 8786:8786 \
     -p 8088:8088 \
     ghcr.io/dask/dask-gateway-ci-hadoop
+
+# The hadoop container's systemd process emits logs about the progress of
+# starting up declared services that we will await.
+#
+# We do it to avoid getting OOMKilled by peaking memory needs during startup,
+# which is prone to happen if we run pip install at the same time.
+#
+# Practically, we await "entered RUNNING state" to be observed exactly 6 times,
+# which represents our 6 systemd services.
+#
+#     INFO success: kadmind entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
+#     INFO success: krb5kdc entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
+#     INFO success: hdfs-namenode entered RUNNING state, process has stayed up for > than 3 seconds (startsecs)
+#     INFO success: hdfs-datanode entered RUNNING state, process has stayed up for > than 3 seconds (startsecs)
+#     INFO success: yarn-resourcemanager entered RUNNING state, process has stayed up for > than 3 seconds (startsecs)
+#     INFO success: yarn-nodemanager entered RUNNING state, process has stayed up for > than 3 seconds (startsecs)
+#
+set +x
+await_startup() {
+    i=0; while [ $i -ne 30 ]; do
+        docker logs hadoop | grep "entered RUNNING state" | wc -l 2>/dev/null | grep --silent "6" \
+            && start_script_finishing=true && break \
+            || start_script_finishing=false && sleep 1 && i=$((i + 1)) && echo "Waiting for hadoop container startup ($i seconds)"
+    done
+    if [ "$start_script_finishing" != "true" ]; then
+        echo "WARNING: /script/start.sh was slow to finish!"
+        exit 1
+    fi
+
+    echo "hadoop container started!"
+}
+await_startup

--- a/continuous_integration/docker/pbs/start.sh
+++ b/continuous_integration/docker/pbs/start.sh
@@ -16,9 +16,10 @@ docker run --rm -d \
     ghcr.io/dask/dask-gateway-ci-pbs
 
 # The pbs container's entrypoint, files/scripts/start.sh, emits a log message
-# that we will await observing. We do it to avoid getting OOMKilled by peaking
-# memory needs during startup, which is prone to happen if we run pip install at
-# the same time.
+# that we will await.
+#
+# We do it to avoid getting OOMKilled by peaking memory needs during startup,
+# which is prone to happen if we run pip install at the same time.
 #
 set +x
 await_startup() {
@@ -32,5 +33,9 @@ await_startup() {
         exit 1
     fi
     echo "pbs container started!"
+
+    # We add some seconds of precautionary sleep to avoid unknown and hard to
+    # debug issues.
+    sleep 3
 }
 await_startup

--- a/continuous_integration/docker/slurm/start.sh
+++ b/continuous_integration/docker/slurm/start.sh
@@ -13,3 +13,34 @@ docker run --rm -d \
     -p 8786:8786 \
     -p 8088:8088 \
     ghcr.io/dask/dask-gateway-ci-slurm
+
+# The slurm container's systemd process emits logs about the progress of
+# starting up declared services that we will await.
+#
+# We do it to avoid getting OOMKilled by peaking memory needs during startup,
+# which is prone to happen if we run pip install at the same time.
+#
+# Practically, we await "entered RUNNING state" to be observed exactly 5 times,
+# which represents our 5 systemd services.
+#
+#     INFO success: mysqld entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
+#     INFO success: slurmdbd entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
+#     INFO success: slurmd entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
+#     INFO success: slurmctld entered RUNNING state, process has stayed up for > than 3 seconds (startsecs)
+#     INFO success: munged entered RUNNING state, process has stayed up for > than 5 seconds (startsecs)
+#
+set +x
+await_startup() {
+    i=0; while [ $i -ne 30 ]; do
+        docker logs slurm | grep "entered RUNNING state" | wc -l 2>/dev/null | grep --silent "5" \
+            && start_script_finishing=true && break \
+            || start_script_finishing=false && sleep 1 && i=$((i + 1)) && echo "Waiting for slurm container startup ($i seconds)"
+    done
+    if [ "$start_script_finishing" != "true" ]; then
+        echo "WARNING: /script/start.sh was slow to finish!"
+        exit 1
+    fi
+
+    echo "slurm container started!"
+}
+await_startup


### PR DESCRIPTION
Attempted to handle #643 but didn't do the trick. Still, these changes are incrementally better as it helps us avoid worrying about not awaiting startup.