### PR TITLE
maint: increase test's wait duration for shutdown of worker processes for distributed>=2022.11.0

### DIFF
--- a/tests/test_local_backend.py
+++ b/tests/test_local_backend.py
@@ -27,7 +27,7 @@ async def test_local_cluster_backend():
                     res = await g.gateway.backend.do_check_workers(db_workers)
                     assert sum(res) == 1
 
-                await with_retries(test, 20)
+                await with_retries(test, 20, 0.5)
 
                 async with cluster.get_client(set_as_default=False) as client:
                     res = await client.submit(lambda x: x + 1, 1)
@@ -40,7 +40,7 @@ async def test_local_cluster_backend():
                     res = await g.gateway.backend.do_check_workers(db_workers)
                     assert sum(res) == 0
 
-                await with_retries(test, 20)
+                await with_retries(test, 20, 0.5)
 
                 # No-op for shutdown of already shutdown worker
                 db_worker = db_workers[0]
@@ -50,4 +50,4 @@ async def test_local_cluster_backend():
                 res = await g.gateway.backend.do_check_clusters([db_cluster])
                 assert res == [False]
 
-            await with_retries(test, 20)
+            await with_retries(test, 20, 0.5)


### PR DESCRIPTION
Previously, apparently <1 second of wait was required to see distributed worker processes shut down. Now we seem to need need `>2,<5`, and I've made it 10 to be safe.

- Closes #648