### PR TITLE
ci: pre-commit.ci to update hooks monthly instead of weekly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,3 +53,7 @@ repos:
     rev: "6.0.0"
     hooks:
       - id: flake8
+
+# pre-commit.ci config reference: https://pre-commit.ci/#configuration
+ci:
+  autoupdate_schedule: monthly


### PR DESCRIPTION
pre-commit.ci's update of hook versions has been a bit too frequent for us in the jupyterhub organization at least. See https://github.com/jupyterhub/team-compass/issues/604.

I requested review to help improve visibility on this change, as its something quite nice to know its possible to adjust.

---

Test failures unrelated and caused by new k8s 1.26 version being out and the action to setup it isn't yet supporting it. Tracked in https://github.com/jupyterhub/action-k3s-helm/issues/85