### PR TITLE
ci: test against python 3.11 (tests are failing)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -62,9 +62,8 @@ jobs:
             go-version: "1.18"
           - python-version: "3.10"
             go-version: "1.19"
-          # FIXME: See https://github.com/dask/dask-gateway/issues/638
-          # - python-version: "3.11"
-          #   go-version: "1.19"
+          - python-version: "3.11"
+            go-version: "1.19"
 
     steps:
       - uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.black]
 line-length = 88
 # target-version should be all supported versions
-target-version = ['py38', 'py39', 'py310']
+target-version = ["py38", "py39", "py310", "py311"]
 
 [tool.isort]
 profile = "black"


### PR DESCRIPTION
- Closes https://github.com/dask/dask-gateway/issues/638