### PR TITLE
Add support for Python 3.11

### DIFF
--- a/dask-gateway-server/dask_gateway_server/backends/db_base.py
+++ b/dask-gateway-server/dask_gateway_server/backends/db_base.py
@@ -882,7 +882,9 @@ class DBBackendBase(Backend):
                     if c.status < JobStatus.STOPPED
                 ]
                 if pending_shutdown:
-                    await asyncio.wait([c.shutdown for c in pending_shutdown])
+                    await asyncio.wait(
+                        [asyncio.ensure_future(c.shutdown) for c in pending_shutdown]
+                    )
 
         # Stop reconcilation queues
         if hasattr(self, "reconcilers"):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -125,13 +125,13 @@ async def test_flag(use_wait):
     async def wait(flag):
         nonlocal triggered
         if use_wait:
-            await asyncio.wait([flag])
+            await asyncio.wait([asyncio.ensure_future(flag)])
         else:
             await flag
         if flag.is_set():
             triggered = True
 
-    res = asyncio.ensure_future(wait(flag))
+    res = wait(flag)
 
     flag.set()
     await res


### PR DESCRIPTION
- Closes #657

Ideas on how to resolve errors in py311 comes from:
- https://github.com/dask/distributed/issues/6785
- https://github.com/dask/distributed/pull/7249
- https://docs.python.org/3/library/asyncio-task.html#asyncio.wait
  > Changed in version 3.11: Passing coroutine objects to wait() directly is forbidden.
- https://docs.python.org/3/library/asyncio-future.html#asyncio.ensure_future

Note that we should ignore the helm test with k8s 1.26, as that is unrelated. The slurm test failure is also unrelated, see #660 about that intermittent failure.