### PR TITLE
maint: increase test's wait duration for shutdown of worker processes for distributed>=2022.11.0, for slurm

### DIFF
--- a/tests/test_slurm_backend.py
+++ b/tests/test_slurm_backend.py
@@ -109,7 +109,7 @@ async def test_slurm_backend():
                     res = await g.gateway.backend.do_check_workers(db_workers)
                     assert sum(res) == 0
 
-                await with_retries(test, 30, 0.25)
+                await with_retries(test, 60, 0.25)
 
             # No-op for shutdown of already shutdown worker
             async def test():


### PR DESCRIPTION
- Similar to #652, but for the slurm test also failing intermittently.