### PR TITLE
Use and fix support for Python 3.11 in Helm chart images

### DIFF
--- a/.github/workflows/build-publish-docs.yaml
+++ b/.github/workflows/build-publish-docs.yaml
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install Python docs requirements
         run: |
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install Python docs requirements
         run: |

--- a/.github/workflows/build-publish-helm-chart.yaml
+++ b/.github/workflows/build-publish-helm-chart.yaml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install chart publishing dependencies (chartpress, pyyaml, helm)
         run: |

--- a/.github/workflows/build-publish-python-packages.yaml
+++ b/.github/workflows/build-publish-python-packages.yaml
@@ -69,7 +69,7 @@ jobs:
       - uses: actions/setup-go@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       - name: Install build package
         run: |

--- a/.github/workflows/refreeze-dockerfile-requirements-txt.yaml
+++ b/.github/workflows/refreeze-dockerfile-requirements-txt.yaml
@@ -39,7 +39,7 @@ jobs:
               --volume=$PWD:/opt/${{ matrix.image }} \
               --workdir=/opt/${{ matrix.image }} \
               --user=root \
-              python:3.10-slim-bullseye \
+              python:3.11-slim-bullseye \
               sh -c 'pip install pip-tools==6.* && pip-compile --upgrade --output-file=Dockerfile.requirements.txt Dockerfile.requirements.in'
 
       - name: git diff

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -148,7 +148,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
 
       # Starts a k8s cluster with NetworkPolicy enforcement and installs both
       # kubectl and helm

--- a/continuous_integration/docker/base/Dockerfile
+++ b/continuous_integration/docker/base/Dockerfile
@@ -7,11 +7,7 @@
 #
 FROM centos:7
 
-# FIXME: As of 2022-11-07, pykerberos didn't have a wheel available making us
-#        need to built it, but also then have gcc available during that time.
-#        Due to this, our test suite is broken.
-#
-ARG python_version="3.10"
+ARG python_version="3.11"
 ARG go_version="1.19"
 
 # Set labels based on the Open Containers Initiative (OCI):

--- a/continuous_integration/docker/hadoop/_install.sh
+++ b/continuous_integration/docker/hadoop/_install.sh
@@ -5,6 +5,7 @@ cd /working
 
 # pykerberos needs to compile c++ code that depends on system libraries, by
 # installing it from conda-forge, we avoid such hassle.
+#
 mamba install -c conda-forge pykerberos
 
 # This installs everything else we need for tests

--- a/continuous_integration/docker/hadoop/_install.sh
+++ b/continuous_integration/docker/hadoop/_install.sh
@@ -6,7 +6,11 @@ cd /working
 # pykerberos needs to compile c++ code that depends on system libraries, by
 # installing it from conda-forge, we avoid such hassle.
 #
-mamba install -c conda-forge pykerberos
+# FIXME: Don't install pyzmq from conda-forge when pyzmq 25.0.0 is released, see
+#        https://github.com/zeromq/pyzmq/issues/1821 and
+#        https://pypi.org/project/pyzmq/.
+#
+mamba install -c conda-forge pykerberos pyzmq
 
 # This installs everything else we need for tests
 pip install -r tests/requirements.txt

--- a/continuous_integration/docker/pbs/_install.sh
+++ b/continuous_integration/docker/pbs/_install.sh
@@ -3,6 +3,12 @@ set -xe
 
 cd /working
 
+# FIXME: Don't install pyzmq from conda-forge when pyzmq 25.0.0 is released, see
+#        https://github.com/zeromq/pyzmq/issues/1821 and
+#        https://pypi.org/project/pyzmq/.
+#
+mamba install -c conda-forge pyzmq
+
 # This installs everything we need for tests
 pip install -r tests/requirements.txt
 

--- a/continuous_integration/docker/slurm/_install.sh
+++ b/continuous_integration/docker/slurm/_install.sh
@@ -3,6 +3,12 @@ set -xe
 
 cd /working
 
+# FIXME: Don't install pyzmq from conda-forge when pyzmq 25.0.0 is released, see
+#        https://github.com/zeromq/pyzmq/issues/1821 and
+#        https://pypi.org/project/pyzmq/.
+#
+mamba install -c conda-forge pyzmq
+
 # This installs everything we need for tests
 pip install -r tests/requirements.txt
 

--- a/dask-gateway-server/Dockerfile
+++ b/dask-gateway-server/Dockerfile
@@ -6,7 +6,7 @@
 # - api pod command:        dask-gateway-server ...
 # - controller pod command: dask-gateway-server kube-controller ...
 #
-FROM python:3.10-slim-bullseye
+FROM python:3.11-slim-bullseye
 
 # Set labels based on the Open Containers Initiative (OCI):
 # https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys

--- a/dask-gateway-server/dask_gateway_server/backends/kubernetes/controller.py
+++ b/dask-gateway-server/dask_gateway_server/backends/kubernetes/controller.py
@@ -412,7 +412,9 @@ class KubeController(KubeBackendAndControllerMixin, Application):
                 on_delete=self.on_endpoints_delete,
             ),
         }
-        await asyncio.wait([i.start() for i in self.informers.values()])
+        await asyncio.wait(
+            [asyncio.ensure_future(i.start()) for i in self.informers.values()]
+        )
         self.log.debug("All informers started")
 
         # Initialize reconcilers
@@ -448,7 +450,9 @@ class KubeController(KubeBackendAndControllerMixin, Application):
             await asyncio.gather(*self.reconcilers, return_exceptions=True)
 
         if hasattr(self, "informers"):
-            await asyncio.wait([i.stop() for i in self.informers.values()])
+            await asyncio.wait(
+                [asyncio.ensure_future(i.stop()) for i in self.informers.values()]
+            )
 
         # Stop background tasks
         if hasattr(self, "task_pool"):

--- a/dask-gateway-server/setup.py
+++ b/dask-gateway-server/setup.py
@@ -243,6 +243,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     keywords="dask hadoop kubernetes HPC distributed cluster",
     description=(

--- a/dask-gateway/Dockerfile
+++ b/dask-gateway/Dockerfile
@@ -21,7 +21,7 @@
 # psutils, a dependency of distributed, is currently the sole reason we have to
 # have this build stage.
 #
-FROM python:3.10-bullseye as build-stage
+FROM python:3.11-bullseye as build-stage
 
 # Build wheels
 #
@@ -40,7 +40,7 @@ RUN --mount=type=cache,target=${PIP_CACHE_DIR} \
 # The final stage
 # ---------------
 #
-FROM python:3.10-slim-bullseye as slim-stage
+FROM python:3.11-slim-bullseye as slim-stage
 
 # Set labels based on the Open Containers Initiative (OCI):
 # https://github.com/opencontainers/image-spec/blob/main/annotations.md#pre-defined-annotation-keys

--- a/dask-gateway/setup.py
+++ b/dask-gateway/setup.py
@@ -36,6 +36,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     keywords="dask hadoop kubernetes HPC distributed cluster",
     description="A client library for interacting with a dask-gateway server",

--- a/dev-environment.yaml
+++ b/dev-environment.yaml
@@ -19,7 +19,7 @@ name: dask-gateway-dev
 channels:
   - conda-forge
 dependencies:
-  - python=3.10
+  - python=3.11
   - pip
 
   # Golang with compiler is required to compile dask-gateway-server's bundled

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -21,6 +21,7 @@ pyyaml
 
 pytest
 pytest-asyncio
+pytest-timeout
 
 # dask-gateway and dask-gateway-server and all their dependencies are assumed to
 # be installed.

--- a/tests/test_pbs_backend.py
+++ b/tests/test_pbs_backend.py
@@ -58,6 +58,7 @@ class PBSTestingBackend(PBSBackend):
         JOBIDS.discard(job_id)
 
 
+@pytest.mark.timeout(90)
 async def test_pbs_backend():
     c = Config()
     c.PBSClusterConfig.scheduler_cmd = "/opt/python/bin/dask-scheduler"

--- a/tests/test_pbs_backend.py
+++ b/tests/test_pbs_backend.py
@@ -63,8 +63,8 @@ async def test_pbs_backend():
     c = Config()
     c.PBSClusterConfig.scheduler_cmd = "/opt/python/bin/dask-scheduler"
     c.PBSClusterConfig.worker_cmd = "/opt/python/bin/dask-worker"
-    c.PBSClusterConfig.scheduler_memory = "128M"
-    c.PBSClusterConfig.worker_memory = "128M"
+    c.PBSClusterConfig.scheduler_memory = "256M"
+    c.PBSClusterConfig.worker_memory = "256M"
     c.PBSClusterConfig.scheduler_cores = 1
     c.PBSClusterConfig.worker_cores = 1
     c.DaskGateway.backend_class = PBSTestingBackend

--- a/tests/test_slurm_backend.py
+++ b/tests/test_slurm_backend.py
@@ -64,6 +64,7 @@ class SlurmTestingBackend(SlurmBackend):
         JOBIDS.discard(job_id)
 
 
+@pytest.mark.timeout(90)
 async def test_slurm_backend():
     c = Config()
 

--- a/tests/test_yarn_backend.py
+++ b/tests/test_yarn_backend.py
@@ -53,8 +53,8 @@ async def test_yarn_backend():
     c = Config()
     c.YarnClusterConfig.scheduler_cmd = "/opt/python/bin/dask-scheduler"
     c.YarnClusterConfig.worker_cmd = "/opt/python/bin/dask-worker"
-    c.YarnClusterConfig.scheduler_memory = "128M"
-    c.YarnClusterConfig.worker_memory = "128M"
+    c.YarnClusterConfig.scheduler_memory = "256M"
+    c.YarnClusterConfig.worker_memory = "256M"
     c.YarnClusterConfig.scheduler_cores = 1
     c.YarnClusterConfig.worker_cores = 1
 

--- a/tests/test_yarn_backend.py
+++ b/tests/test_yarn_backend.py
@@ -47,6 +47,7 @@ class YarnTestingBackend(YarnBackend):
         _APPIDS.discard(appid)
 
 
+@pytest.mark.timeout(90)
 async def test_yarn_backend():
 
     c = Config()


### PR DESCRIPTION
## Summary of changes

### Helm chart
- Complements #659 with fixes in the k8s dask-cluster controller
- Builds dask-gateway-server image to use Python 3.11
- Builds dask-gateway image used for testing by scheduler and worker to use Python 3.11

### CI System
- Fix for pyzmq not having a wheel for Centos 7 (manylinux_2_17 aka manylinux2014 needed)
- Fix for #643 - the scheduler and/or workers ran out of memory
- Adds pytest-timeout to provide logs before timing out