### PR TITLE
client: fix failure to display widget with ipywidgets 8

### DIFF
--- a/dask-gateway/dask_gateway/client.py
+++ b/dask-gateway/dask_gateway/client.py
@@ -1221,16 +1221,12 @@ class GatewayCluster:
         return box
 
     def _ipython_display_(self, **kwargs):
+        from IPython.display import display
+
         widget = self._widget()
         if widget is not None:
-            # ipywidgets renamed the _ipython_display_ method in 8.x
-            try:
-                return widget._ipython_display_(**kwargs)
-            except AttributeError:
-                return widget._repr_mimebundle_(**kwargs)
+            display(widget, **kwargs)
         else:
-            from IPython.display import display
-
             data = {"text/plain": repr(self), "text/html": self._repr_html_()}
             display(data, raw=True)
 

--- a/dask-gateway/dask_gateway/options.py
+++ b/dask-gateway/dask_gateway/options.py
@@ -74,11 +74,9 @@ class Options(MutableMapping):
     def _ipython_display_(self, **kwargs):
         widget = self._widget()
         if widget is not None:
-            # ipywidgets renamed the _ipython_display_ method in 8.x
-            try:
-                return widget._ipython_display_(**kwargs)
-            except AttributeError:
-                return widget._repr_mimebundle_(**kwargs)
+            from IPython.display import display
+
+            display(widget, **kwargs)
         from IPython.lib.pretty import pprint
 
         pprint(self)


### PR DESCRIPTION
Rather than calling `widget._ipython_display_()` use `display(widget)`, this should support older and newer versions of `ipywidget`.

Closes #671 