### PR TITLE
Update RELEASE.md to use tbump

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,16 +29,16 @@ repos:
           - --py38-plus
 
   # Autoformat: Python code
-  - repo: https://github.com/psf/black
-    rev: "22.12.0"
-    hooks:
-      - id: black
-
-  # Autoformat: Python code
   - repo: https://github.com/PyCQA/isort
     rev: "5.11.4"
     hooks:
       - id: isort
+
+  # Autoformat: Python code
+  - repo: https://github.com/psf/black
+    rev: "22.12.0"
+    hooks:
+      - id: black
 
   # Autoformat: general small fixes
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,48 +1,68 @@
-# Release process
+# How to make a release
 
-Follow these steps to cut a new release.
+`dask-gateway` and `dask-gateway-server` are packages available on [PyPI] and
+[conda-forge], and `dask-gateway` is a Helm chart available at [helm.dask.org]
+which is both a user facing website and a Helm chart repository by having an
+[index.yaml] file read by `helm` the CLI linking to packaged Helm charts.
 
-- Update frozen Dockerfile.requirements.txt files by running workflow that has
-  automated this at
-  https://github.com/dask/dask-gateway/actions/workflows/refreeze-dockerfile-requirements-txt.yaml
-  and merging the PRs.
+These are instructions on how to make a release.
 
-- Update `docs/changelog.md` in a dedicated PR
+## Pre-requisites
 
-  - Generate a list of PRs using [executablebooks/github-activity](https://github.com/executablebooks/github-activity)
+- Push rights to [dask/dask-gateway]
+- Push rights to [conda-forge/dask-gateway-feedstock]
 
-    ```bash
-    pip install --upgrade github-activity
-    github-activity --output github-activity-output.md
-    ```
+## Steps to make a release
 
-  - Visit and label all uncategorized PRs appropriately with: `maintenance`, `enhancement`, `new`, `breaking`, `bug`, or `documentation`.
+1. Refreeze Dockerfile.requirements.txt files by running the [refreeze workflow]
+   and merging created PRs.
+
+   [refreeze workflow]: https://github.com/dask/dask-gateway/actions/workflows/refreeze-dockerfile-requirements-txt.yaml
+
+1. Create a PR updating `docs/source/changelog.md` with [github-activity] and
+   continue only when its merged.
+
+   ```shell
+   pip install github-activity
+
+   github-activity --heading-level=2 dask/dask-gateway
+   ```
+
+  - Visit and label all uncategorized PRs appropriately with: `maintenance`,
+    `enhancement`, `new`, `breaking`, `bug`, or `documentation`.
   - Generate a list of PRs again and add it to the changelog
   - Highlight breaking changes
   - Summarize the release changes
 
-- Create a version bumping commit and push a git tag
+2. Checkout main and make sure it is up to date.
 
-  ```bash
-  # VERSION should be for example 2022.4.0, not including a leading zero in the month!
-  VERSION=...
-  git fetch origin
-  git checkout main
-  git reset --hard origin/main
+   ```shell
+   git checkout main
+   git fetch origin main
+   git reset --hard origin/main
+   git clean -xfd
+   ```
 
-  # Update dask-gateway/dask_gateway/_version.py
-  # Update dask-gateway-server/dask_gateway_server/_version.py
-  # Update resources/helm/dask-gateway/Chart.yaml
-  git add .
-  git commit -m "Release $VERSION"
+3. Update the version, make commits, and push a git tag with `tbump`.
 
-  git tag -a $VERSION -m $VERSION
-  git push --atomic --follow-tags origin main
-  ```
+   ```shell
+   pip install tbump
+   tbump --dry-run ${VERSION}
 
-- You can now verify that
+   tbump ${VERSION}
+   ```
 
-  - The Python packages was published to PyPI: https://pypi.org/project/dask-gateway and https://pypi.org/project/dask-gateway-server
-  - The Helm chart was pushed to our GitHub based Helm chart repo: https://github.com/dask/helm-chart/tree/gh-pages
+   Following this, the [CI system] will build and publish the PyPI packages and
+   Helm chart.
 
-- Finally await and review/merge the automated pull requests that will follow to the [conda-forge feedstock](https://github.com/conda-forge/dask-gateway-feedstock/pulls) repository.
+4. Following the release to PyPI, an automated PR should arrive to
+   [conda-forge/jupyterhub-feedstock] with instructions.
+
+[pypi]: https://pypi.org/project/dask-gateway/
+[conda-forge]: https://anaconda.org/conda-forge/dask-gateway
+[helm.dask.org]: https://helm.dask.org/
+[index.yaml]: https://helm.dask.org/index.yaml
+[dask/dask-gateway]: https://github.com/dask/dask-gateway
+[conda-forge/dask-gateway-feedstock]: https://github.com/conda-forge/jupyterhub-feedstock
+[github-activity]: https://github.com/executablebooks/github-activity
+[ci system]: https://github.com/dask/dask-gateway/actions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,18 +1,66 @@
-[tool.black]
-line-length = 88
-# target-version should be all supported versions
-target-version = ["py38", "py39", "py310", "py311"]
-
+# isort is used for autoformatting Python code
+#
+# ref: https://pycqa.github.io/isort/
+#
 [tool.isort]
 profile = "black"
 
-[tool.pytest.ini_options]
-# GitHub Actions make it hard for pytest to conclude it should use colors, due
-# to this we explicitly make it do so. This is related to:
-# https://github.com/actions/runner/issues/241
-addopts = '--color=yes'
 
-# asyncio_mode auto makes us not need to decorate our async test functions with
-# @pytest.mark.asyncio, for more details see:
-# https://github.com/pytest-dev/pytest-asyncio#auto-mode
-asyncio_mode = 'auto'
+# black is used for autoformatting Python code
+#
+# ref: https://black.readthedocs.io/en/stable/
+#
+[tool.black]
+line-length = 88
+target_version = [
+    "py38",
+    "py39",
+    "py310",
+    "py311",
+]
+
+
+# pytest is used for running Python based tests
+#
+# ref: https://docs.pytest.org/en/stable/
+#
+[tool.pytest.ini_options]
+addopts = "--verbose --color=yes --durations=10"
+asyncio_mode = "auto"
+
+
+# tbump is used to simplify and standardize the release process when updating
+# the version, making a git commit and tag, and pushing changes.
+#
+# ref: https://github.com/your-tools/tbump#readme
+#
+[tool.tbump]
+github_url = "https://github.com/dask/dask-gateway"
+
+[tool.tbump.version]
+current = "2023.1.0"
+regex = '''
+    (?P<major>\d+)
+    \.
+    (?P<minor>\d+)
+    \.
+    (?P<patch>\d+)
+    \.?
+    (?P<pre>((alpha|beta|rc)\.\d+)|)
+'''
+
+[tool.tbump.git]
+message_template = "Release {new_version}"
+tag_template = "{new_version}"
+
+[[tool.tbump.file]]
+src = "dask-gateway/dask_gateway/_version.py"
+search = '__version__ = "{current_version}"'
+
+[[tool.tbump.file]]
+src = "dask-gateway-server/dask_gateway_server/_version.py"
+search = '__version__ = "{current_version}"'
+
+[[tool.tbump.file]]
+src = "resources/helm/dask-gateway/Chart.yaml"
+search = 'appVersion: "{current_version}"'


### PR DESCRIPTION
From manually needing to update, commit, tag, and push three files with version fields - we now do it all with a tbump command. This command will also summarize clearly what it will do via `tbump --dry-run <version>` as also suggested in the REALEASE.md file before one does it without --dry-run.

And, the config on what files to update etc are nicely located into a pyproject.toml file.