### PR TITLE
client: fix double display of Options in jupyter

### DIFF
--- a/dask-gateway/dask_gateway/options.py
+++ b/dask-gateway/dask_gateway/options.py
@@ -77,6 +77,7 @@ class Options(MutableMapping):
             from IPython.display import display
 
             display(widget, **kwargs)
+            return
         from IPython.lib.pretty import pprint
 
         pprint(self)


### PR DESCRIPTION
This was missed in #672. After displaying options as a widget, textual representation is also displayed.

