### PR TITLE
sqlalchemy 2.0

### DIFF
--- a/dask-gateway-server/setup.py
+++ b/dask-gateway-server/setup.py
@@ -208,12 +208,12 @@ extras_require = {
     # pykerberos is tricky to install and requires a system package to
     # successfully compile some C code, on ubuntu this is libkrb5-dev.
     "kerberos": ["pykerberos"],
-    "jobqueue": ["sqlalchemy"],
-    "local": ["sqlalchemy"],
-    "yarn": ["sqlalchemy", "skein >= 0.7.3"],
+    "jobqueue": ["sqlalchemy>=2.0.0"],
+    "local": ["sqlalchemy>=2.0.0"],
+    "yarn": ["sqlalchemy>=2.0.0", "skein >= 0.7.3"],
     "kubernetes": ["kubernetes_asyncio"],
     "all_backends": [
-        "sqlalchemy",
+        "sqlalchemy>=2.0.0",
         "skein >= 0.7.3",
         "kubernetes_asyncio",
     ],

--- a/tests/test_db_backend.py
+++ b/tests/test_db_backend.py
@@ -285,7 +285,7 @@ def check_db_consistency(db):
 
     with db.db.begin() as conn:
         clusters = conn.execute(db_base.clusters.select()).fetchall()
-        workers =  conn.execute(db_base.workers.select()).fetchall()
+        workers = conn.execute(db_base.workers.select()).fetchall()
 
     # Check cluster state
     for c in clusters:


### PR DESCRIPTION
This adds compatibility for sqlalchemy 2.0. It also *requires* sqlalchemy 2.0. I didn't look deeply, but IMO we don't have the maintainer bandwidth to try to support both.

Closes #679 