### PR TITLE
Adding envs key Helm values to gateway resources

### DIFF
--- a/resources/helm/dask-gateway/templates/controller/deployment.yaml
+++ b/resources/helm/dask-gateway/templates/controller/deployment.yaml
@@ -43,11 +43,6 @@ spec:
         - name: controller
           image: {{ .Values.controller.image.name }}:{{ .Values.controller.image.tag }}
           imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
-          env:
-          {{- range $key, $value := .Values.controller.envs }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-          {{- end }}
           args:
             - dask-gateway-server
             - kube-controller

--- a/resources/helm/dask-gateway/templates/controller/deployment.yaml
+++ b/resources/helm/dask-gateway/templates/controller/deployment.yaml
@@ -43,6 +43,11 @@ spec:
         - name: controller
           image: {{ .Values.controller.image.name }}:{{ .Values.controller.image.tag }}
           imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
+          env:
+          {{- range $key, $value := .Values.controller.envs }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+          {{- end }}
           args:
             - dask-gateway-server
             - kube-controller

--- a/resources/helm/dask-gateway/templates/gateway/deployment.yaml
+++ b/resources/helm/dask-gateway/templates/gateway/deployment.yaml
@@ -54,9 +54,8 @@ spec:
             - mountPath: /etc/dask-gateway/
               name: configmap
           env:
-            {{- range .Values.gateway.env }}
-            - name: {{ .name }}
-              value: {{ .value| quote }}
+            {{- with .Values.gateway.env }}
+            {{- . | toYaml | nindent 12 }}
             {{- end }}
             {{- if (eq .Values.gateway.auth.type "jupyterhub") }}
             - name: JUPYTERHUB_API_TOKEN

--- a/resources/helm/dask-gateway/templates/gateway/deployment.yaml
+++ b/resources/helm/dask-gateway/templates/gateway/deployment.yaml
@@ -54,7 +54,7 @@ spec:
             - mountPath: /etc/dask-gateway/
               name: configmap
           env:
-            {{- range .Values.controller.env }}
+            {{- range .Values.gateway.env }}
             - name: {{ .name }}
               value: {{ .value| quote }}
             {{- end }}

--- a/resources/helm/dask-gateway/templates/gateway/deployment.yaml
+++ b/resources/helm/dask-gateway/templates/gateway/deployment.yaml
@@ -42,6 +42,11 @@ spec:
         - name: gateway
           image: {{ .Values.gateway.image.name }}:{{ .Values.gateway.image.tag }}
           imagePullPolicy: {{ .Values.gateway.image.pullPolicy }}
+          env:
+          {{- range $key, $value := .Values.gateway.envs }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+          {{- end }}
           args:
             - dask-gateway-server
             - --config

--- a/resources/helm/dask-gateway/templates/gateway/deployment.yaml
+++ b/resources/helm/dask-gateway/templates/gateway/deployment.yaml
@@ -42,11 +42,6 @@ spec:
         - name: gateway
           image: {{ .Values.gateway.image.name }}:{{ .Values.gateway.image.tag }}
           imagePullPolicy: {{ .Values.gateway.image.pullPolicy }}
-          env:
-          {{- range $key, $value := .Values.gateway.envs }}
-            - name: {{ $key }}
-              value: {{ $value | quote }}
-          {{- end }}
           args:
             - dask-gateway-server
             - --config
@@ -59,6 +54,10 @@ spec:
             - mountPath: /etc/dask-gateway/
               name: configmap
           env:
+            {{- range .Values.controller.env }}
+            - name: {{ .name }}
+              value: {{ .value| quote }}
+            {{- end }}
             {{- if (eq .Values.gateway.auth.type "jupyterhub") }}
             - name: JUPYTERHUB_API_TOKEN
               valueFrom:

--- a/resources/helm/dask-gateway/values.schema.yaml
+++ b/resources/helm/dask-gateway/values.schema.yaml
@@ -108,7 +108,7 @@ properties:
           See [the Kubernetes
           documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
           for more details about annotations.
-      envs: &envs-spec
+      env: &env-spec
         type: array
         items:
           type: object
@@ -434,7 +434,6 @@ properties:
         properties: *image-properties
       imagePullSecrets: *imagePullSecrets-spec
       annotations: *labels-and-annotations-spec
-      envs: *envs-spec
       resources: *resources-spec
       nodeSelector: *nodeSelector-spec
       affinity: *affinity-spec

--- a/resources/helm/dask-gateway/values.schema.yaml
+++ b/resources/helm/dask-gateway/values.schema.yaml
@@ -108,7 +108,7 @@ properties:
           See [the Kubernetes
           documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
           for more details about annotations.
-      env: &env-spec
+      env:
         type: array
         items:
           type: object
@@ -116,17 +116,16 @@ properties:
           properties:
             name:
               type: string
-              description: |
-                The name of the environment variable to pass to the pod
             value:
               type: string
-              description: |
-                The value of the environment variable to pass to the pod
+            valueFrom:
+              type: object
+              additionalProperties: true
           required:
             - name
-            - value
         description: |
-          Additional environment variables to apply to the resource
+          A k8s specification for passing additional environment variables
+          to the gateway. See [the documentation](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#envvar-v1-core)
       resources: &resources-spec
         type: object
         additionalProperties: true

--- a/resources/helm/dask-gateway/values.schema.yaml
+++ b/resources/helm/dask-gateway/values.schema.yaml
@@ -125,7 +125,7 @@ properties:
             - name
         description: |
           A k8s specification for passing additional environment variables
-          to the gateway. See [the documentation](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#envvar-v1-core)
+          to the gateway. See [the documentation](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#envvar-v1-core)
       resources: &resources-spec
         type: object
         additionalProperties: true

--- a/resources/helm/dask-gateway/values.schema.yaml
+++ b/resources/helm/dask-gateway/values.schema.yaml
@@ -108,6 +108,25 @@ properties:
           See [the Kubernetes
           documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
           for more details about annotations.
+      envs: &envs-spec
+        type: array
+        items:
+          type: object
+          additionalProperties: false
+          properties:
+            name:
+              type: string
+              description: |
+                The name of the environment variable to pass to the pod
+            value:
+              type: string
+              description: |
+                The value of the environment variable to pass to the pod
+          required:
+            - name
+            - value
+        description: |
+          Additional environment variables to apply to the resource
       resources: &resources-spec
         type: object
         additionalProperties: true
@@ -415,6 +434,7 @@ properties:
         properties: *image-properties
       imagePullSecrets: *imagePullSecrets-spec
       annotations: *labels-and-annotations-spec
+      envs: *envs-spec
       resources: *resources-spec
       nodeSelector: *nodeSelector-spec
       affinity: *affinity-spec

--- a/resources/helm/dask-gateway/values.yaml
+++ b/resources/helm/dask-gateway/values.yaml
@@ -36,10 +36,10 @@ gateway:
 
   # Add additional environment variables to the gateway pod
   # e.g.
-  # envs:
+  # env:
   # - name: MYENV
   #   value: "my value"
-  envs: []
+  env: []
 
   # Image pull secrets for gateway-server pod
   imagePullSecrets: []
@@ -222,13 +222,6 @@ controller:
     name: ghcr.io/dask/dask-gateway-server
     tag: "set-by-chartpress"
     pullPolicy: IfNotPresent
-
-  # Add additional environment variables to the controller pod
-  # e.g.
-  # envs:
-  # - name: MYENV
-  #   value: "my value"
-  envs: []
 
   # Settings for nodeSelector, affinity, and tolerations for the controller pods
   nodeSelector: {}

--- a/resources/helm/dask-gateway/values.yaml
+++ b/resources/helm/dask-gateway/values.yaml
@@ -34,6 +34,13 @@ gateway:
     tag: "set-by-chartpress"
     pullPolicy: IfNotPresent
 
+  # Add additional environment variables to the gateway pod
+  # e.g.
+  # envs:
+  # - name: MYENV
+  #   value: "my value"
+  envs: []
+
   # Image pull secrets for gateway-server pod
   imagePullSecrets: []
 
@@ -215,6 +222,13 @@ controller:
     name: ghcr.io/dask/dask-gateway-server
     tag: "set-by-chartpress"
     pullPolicy: IfNotPresent
+
+  # Add additional environment variables to the controller pod
+  # e.g.
+  # envs:
+  # - name: MYENV
+  #   value: "my value"
+  envs: []
 
   # Settings for nodeSelector, affinity, and tolerations for the controller pods
   nodeSelector: {}

--- a/resources/helm/testing/chart-install-values.yaml
+++ b/resources/helm/testing/chart-install-values.yaml
@@ -1,7 +1,7 @@
 gateway:
   loglevel: DEBUG
   prefix: /services/dask-gateway
-  envs:
+  env:
   - name: MY_ENV
     value: My env
   backend:
@@ -21,9 +21,6 @@ controller:
   loglevel: DEBUG
   completedClusterMaxAge: 60
   completedClusterCleanupPeriod: 30
-  envs:
-  - name: MY_ENV
-    value: My env
 
 traefik:
   loglevel: INFO

--- a/resources/helm/testing/chart-install-values.yaml
+++ b/resources/helm/testing/chart-install-values.yaml
@@ -9,6 +9,10 @@ gateway:
       resourceFieldRef:
         containerName: gateway
         resource: requests.cpu
+  - name: MY_HOSTIP
+    valueFrom:
+      fieldRef:
+        fieldPath: status.hostIP
   backend:
     scheduler:
       cores:

--- a/resources/helm/testing/chart-install-values.yaml
+++ b/resources/helm/testing/chart-install-values.yaml
@@ -1,6 +1,9 @@
 gateway:
   loglevel: DEBUG
   prefix: /services/dask-gateway
+  envs:
+  - name: MY_ENV
+    value: My env
   backend:
     scheduler:
       cores:
@@ -18,6 +21,9 @@ controller:
   loglevel: DEBUG
   completedClusterMaxAge: 60
   completedClusterCleanupPeriod: 30
+  envs:
+  - name: MY_ENV
+    value: My env
 
 traefik:
   loglevel: INFO

--- a/resources/helm/testing/chart-install-values.yaml
+++ b/resources/helm/testing/chart-install-values.yaml
@@ -4,6 +4,11 @@ gateway:
   env:
   - name: MY_ENV
     value: My env
+  - name: MY_CPU_REQUESTS
+    valueFrom:
+      resourceFieldRef:
+        containerName: gateway
+        resource: requests.cpu
   backend:
     scheduler:
       cores:


### PR DESCRIPTION
This MR is to enhance this use-case where one wishes to customize the extraConfig that's passed to the gateway via the configmap.  Currently, [according to the documentation](https://gateway.dask.org/install-kube.html#using-extraconfig), you can create additional python configuration for any of the Traitlet-enhanced classes from the "[Configuration Reference"](https://gateway.dask.org/api-server.html). 

However, it would be nice to be able to pass in environment variables to that config, so you could set the python config additions, but tune them by making a change to an environment variable rather than via making python code changes. 

Take this simple Helm values file example: 

```yaml
gateway:
  extraConfig:
    # Note that the key name here doesn't matter. Values in the
    # `extraConfig` map are concatenated, sorted by key name.
    clusteroptions: |
      c.KubeClusterConfig.idle_timeout = 300
      c.KubeClusterConfig.cluster_max_memory = "20G"
```
If I wanted to customize the config values, I'd have to override the entire config, or create a new "extraConfig" key.

However, it would be nice to be able to do the following:

```yaml
gateway:
  envs:
  - name: IDLE_TIMEOUT
    value: "500"
  extraConfig:
    # Note that the key name here doesn't matter. Values in the
    # `extraConfig` map are concatenated, sorted by key name.
    clusteroptions: |
      import os
      idle_timeout =  int(os.environ.get("IDLE_TIMEOUT", 300))
      cluster_max_memory = os.environ.get("CLUSTER_MAX_MEMORY", "20G")
      c.KubeClusterConfig.idle_timeout = idle_timeout
      c.KubeClusterConfig.cluster_max_memory = cluster_max_memory

```

Then, you could easily change those config values by passing in environment variables to the helm chart without having to change the python code. 

This MR is to change the helm chart so that it accepts an "envs" list of dicts that get passed to the gateway deployment where the dask gateway config ConfigMap gets passed into the gateway. 

Does this sound like a feature that would be useful? 




