### PR TITLE
Pin setuptools to v63 and fix failing tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -86,7 +86,23 @@ jobs:
       - name: Install Python test requirements
         run: |
           pip install -r tests/requirements.txt
-          pip list
+
+      - name: List Python dependencies
+        run: |
+          pip freeze
+
+      - name: Check that golang binary was built
+        run: |
+          echo "As part of installing dask-gateway-server, a golang binary"
+          echo "should be built and bundled, this checks that it was."
+
+          FILE=dask-gateway-server/dask_gateway_server/proxy/dask-gateway-proxy
+          if [ -f "$FILE" ]; then
+              echo "$FILE exists."
+          else
+              echo "$FILE does not exist."
+              exit 1
+          fi
 
       - name: Run Python tests
         run: |

--- a/dask-gateway-server/pyproject.toml
+++ b/dask-gateway-server/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+requires = [
+    # setuptools is pinned to 63 because 64+ has introduced the "editable_wheel"
+    # command to replace the "develop" command, and that doesn't respect
+    # package_data config. We rely on that to get our golang built proxy
+    # accessible currently!
+    #
+    # Message when using "setuptools>=64" during "pip install --editable .":
+    #
+    #     Editable install will be performed using a meta path finder.
+    #
+    #     Options like `package-data`, `include/exclude-package-data` or
+    #     `packages.find.exclude/include` may have no effect.
+    #
+    # The problematic result is that we end up without a golang binary in
+    # dask_gateway_server/proxy/dask-gateway-proxy.
+    #
+    # This is tracked in https://github.com/dask/dask-gateway/issues/740 and can
+    # be discussed further there.
+    #
+    "setuptools==63.*",
+    "wheel",
+]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
- Fixes #709 to a large extent, but does it by introducing a workaround tracked in #740. What remains to be fixed is something I intend to fix in #739 by dropping Python 3.8 support.

I also removed a try block, as we now declare wheel explicitly as a build env dependency via pyproject.toml