### PR TITLE
Fix command applying CRDs from bad release in changelog

### DIFF
--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -15,8 +15,8 @@
   below:
 
   ```shell
-  kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/dask/dask-gateway/2022.11.0/resources/helm/dask-gateway/crds/daskclusters.yaml
-  kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/dask/dask-gateway/2022.11.0/resources/helm/dask-gateway/crds/traefik.yaml
+  kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/dask/dask-gateway/2023.9.0/resources/helm/dask-gateway/crds/daskclusters.yaml
+  kubectl apply --server-side --force-conflicts -f https://raw.githubusercontent.com/dask/dask-gateway/2023.9.0/resources/helm/dask-gateway/crds/traefik.yaml
   ```
 
 ### New features added


### PR DESCRIPTION
Hey! Noticed the [Breaking Changes section in the changelog for the 2023.9.0 release](https://gateway.dask.org/changelog.html#breaking-changes) has people manually update CRDs with `kubectl`. The problem is the command will force-apply the CRDs from the much older 2022.11.0 release. 

This PR updates the commands in the changelog so the command applies resources from the 2023.9.0 release.