### PR TITLE
k8s controller: round to worker cores to three digits, not one

### DIFF
--- a/dask-gateway-server/dask_gateway_server/backends/kubernetes/controller.py
+++ b/dask-gateway-server/dask_gateway_server/backends/kubernetes/controller.py
@@ -1139,8 +1139,8 @@ class KubeController(KubeBackendAndControllerMixin, Application):
             "env": env,
             "imagePullPolicy": config.image_pull_policy,
             "resources": {
-                "requests": {"cpu": f"{cpu_req:.1f}", "memory": str(mem_req)},
-                "limits": {"cpu": f"{cpu_lim:.1f}", "memory": str(mem_lim)},
+                "requests": {"cpu": f"{cpu_req:.3f}", "memory": str(mem_req)},
+                "limits": {"cpu": f"{cpu_lim:.3f}", "memory": str(mem_lim)},
             },
             "volumeMounts": [
                 {

--- a/tests/kubernetes/test_methods.py
+++ b/tests/kubernetes/test_methods.py
@@ -173,16 +173,16 @@ def test_make_pod(is_worker):
         tolerations = config.worker_extra_pod_config["tolerations"]
         workdir = "/worker"
         resources = {
-            "limits": {"cpu": "3.0", "memory": str(6 * 2**30)},
-            "requests": {"cpu": "2.0", "memory": str(4 * 2**30)},
+            "limits": {"cpu": "3.000", "memory": str(6 * 2**30)},
+            "requests": {"cpu": "2.000", "memory": str(4 * 2**30)},
         }
     else:
         component = "dask-scheduler"
         tolerations = config.scheduler_extra_pod_config["tolerations"]
         workdir = "/scheduler"
         resources = {
-            "limits": {"cpu": "2.0", "memory": str(3 * 2**30)},
-            "requests": {"cpu": "1.0", "memory": str(2 * 2**30)},
+            "limits": {"cpu": "2.000", "memory": str(3 * 2**30)},
+            "requests": {"cpu": "1.000", "memory": str(2 * 2**30)},
         }
 
     labels = pod["metadata"]["labels"]


### PR DESCRIPTION
I believe that CPU requests as enforced by the container runtimes associated with k8s clusters often has a resolution to millicores or 0.001 of a core, so going for three decimals makes us not loose resolution without introducing loads of decimals.

- Fixes #765 