### PR TITLE
No longer explicitly set imagePullPolicy to IfNotPresent by default

### DIFF
--- a/dask-gateway-server/dask_gateway_server/backends/kubernetes/backend.py
+++ b/dask-gateway-server/dask_gateway_server/backends/kubernetes/backend.py
@@ -49,7 +49,8 @@ class KubeClusterConfig(ClusterConfig):
     )
 
     image_pull_policy = Unicode(
-        "IfNotPresent",
+        None,
+        allow_none=True,
         help="The image pull policy of the docker image specified in ``image``",
         config=True,
     )

--- a/dask-gateway-server/dask_gateway_server/backends/kubernetes/controller.py
+++ b/dask-gateway-server/dask_gateway_server/backends/kubernetes/controller.py
@@ -1137,7 +1137,6 @@ class KubeController(KubeBackendAndControllerMixin, Application):
             "image": config.image,
             "args": cmd,
             "env": env,
-            "imagePullPolicy": config.image_pull_policy,
             "resources": {
                 "requests": {"cpu": f"{cpu_req:.3f}", "memory": str(mem_req)},
                 "limits": {"cpu": f"{cpu_lim:.3f}", "memory": str(mem_lim)},
@@ -1155,6 +1154,8 @@ class KubeController(KubeBackendAndControllerMixin, Application):
                 {"name": "api", "containerPort": 8788},
             ],
         }
+        if config.image_pull_policy:
+            container["imagePullPolicy"] = config.image_pull_policy
 
         container.update(probes)
 

--- a/resources/helm/dask-gateway/values.yaml
+++ b/resources/helm/dask-gateway/values.yaml
@@ -32,7 +32,7 @@ gateway:
   image:
     name: ghcr.io/dask/dask-gateway-server
     tag: "set-by-chartpress"
-    pullPolicy: IfNotPresent
+    pullPolicy:
 
   # Add additional environment variables to the gateway pod
   # e.g.
@@ -122,7 +122,7 @@ gateway:
     image:
       name: ghcr.io/dask/dask-gateway
       tag: "set-by-chartpress"
-      pullPolicy: IfNotPresent
+      pullPolicy:
 
     # Image pull secrets for a dask cluster's scheduler and worker pods
     imagePullSecrets: []
@@ -221,7 +221,7 @@ controller:
   image:
     name: ghcr.io/dask/dask-gateway-server
     tag: "set-by-chartpress"
-    pullPolicy: IfNotPresent
+    pullPolicy:
 
   # Settings for nodeSelector, affinity, and tolerations for the controller pods
   nodeSelector: {}
@@ -247,7 +247,7 @@ traefik:
   image:
     name: traefik
     tag: "2.10.4"
-    pullPolicy: IfNotPresent
+    pullPolicy:
   imagePullSecrets: []
 
   # Any additional arguments to forward to traefik


### PR DESCRIPTION
This PR is inspired by https://github.com/jupyterhub/kubespawner/pull/807.

This PR influences the specific situation when a `latest` tagged image is to be used, then omiting the imagePullPolicy will result in a changed behavior to instead act as if imagePullPolicy was specified to `Always`. For any other image tag, omitting `imagePullPolicy` still behaves as if its set to `IfNotPresent`.