### PR TITLE
Make dependency on async-timeout explicit and conditional to python 3.10 and older

### DIFF
--- a/dask-gateway-server/dask_gateway_server/backends/db_base.py
+++ b/dask-gateway-server/dask_gateway_server/backends/db_base.py
@@ -2,12 +2,12 @@ import asyncio
 import base64
 import json
 import os
+import sys
 import uuid
 from collections import defaultdict
 from itertools import chain, islice
 
 import sqlalchemy as sa
-from async_timeout import timeout
 from cryptography.fernet import Fernet, MultiFernet
 from traitlets import Bool, Float, Integer, List, Unicode, default, validate
 
@@ -17,6 +17,11 @@ from ..tls import new_keypair
 from ..utils import Flag, FrozenAttrDict, TaskPool, normalize_address, timestamp
 from ..workqueue import Backoff, WorkQueue, WorkQueueClosed
 from .base import Backend
+
+if sys.version_info >= (3, 11):
+    from asyncio import timeout
+else:
+    from async_timeout import timeout
 
 __all__ = ("DBBackendBase", "Cluster", "Worker")
 

--- a/dask-gateway-server/requirements.txt
+++ b/dask-gateway-server/requirements.txt
@@ -1,6 +1,7 @@
 # These are dependencies for installing the dask-gateway-server package.
 #
 aiohttp
+async-timeout
 colorlog
 cryptography
 traitlets>=5.2.2.post1

--- a/dask-gateway-server/requirements.txt
+++ b/dask-gateway-server/requirements.txt
@@ -1,7 +1,7 @@
 # These are dependencies for installing the dask-gateway-server package.
 #
 aiohttp
-async-timeout
+async-timeout ; python_version < "3.11"
 colorlog
 cryptography
 traitlets>=5.2.2.post1

--- a/tests/kubernetes/test_integration.py
+++ b/tests/kubernetes/test_integration.py
@@ -1,10 +1,15 @@
 import os
+import sys
 
 import dask_gateway
 import pytest
-from async_timeout import timeout
 
 from ..utils_test import wait_for_workers, with_retries
+
+if sys.version_info >= (3, 11):
+    from asyncio import timeout
+else:
+    from async_timeout import timeout
 
 kubernetes_asyncio = pytest.importorskip("kubernetes_asyncio")
 


### PR DESCRIPTION
`dask-gateway-server` was depending on `async-timeout` without explicitly listing it as a dependency, causing it to fail installing since our dependency `aiohttp` removed it as an explicit dependency for python 3.11+ in https://github.com/aio-libs/aiohttp/pull/7556.

In this PR dask-gateway-server now does what `aiohttp` did, they transition to rely on the `asyncio` base library's `timeout` function that in Py311+, that now also act as a context manager in `with` statements.