### PR TITLE
ci: add test for python 3.12

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -62,6 +62,8 @@ jobs:
             go-version: "1.21"
           - python-version: "3.11"
             go-version: "1.21"
+          - python-version: "3.12"
+            go-version: "1.21"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Fails due to #740, caused by a too old pinned `setuptools` in dask-gateway-server's build environment.