### PR TITLE
ci: make upload/download artifact compatible with new action version

### DIFF
--- a/.github/workflows/build-publish-python-packages.yaml
+++ b/.github/workflows/build-publish-python-packages.yaml
@@ -90,14 +90,14 @@ jobs:
         if: matrix.upload_sdist
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.package }}
+          name: ${{ format('{0}_{1}', matrix.package, 'sdist') }}
           path: ${{ matrix.package }}/dist/*.tar.gz
           if-no-files-found: error
 
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.package }}
+          name: ${{ join([ format('{0}_{1}', matrix.package, 'wheel'), matrix.GOOS , matrix.GOARCH], '-') }}
           path: ${{ matrix.package }}/dist/*.whl
           if-no-files-found: error
 
@@ -116,8 +116,9 @@ jobs:
       - name: Download built source distributions and wheels
         uses: actions/download-artifact@v4
         with:
-          name: ${{ matrix.package }}
+          pattern: ${{ matrix.package }}_*
           path: ${{ matrix.package }}/dist
+          merge-multiple: true
 
       - name: Inspect built source distributions and wheels
         working-directory: ${{ matrix.package }}

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -112,4 +112,4 @@ both the cluster backend and the authentication protocol are pluggable.
 .. _PBS: ttps://www.openpbs.org/
 .. _Slurm: https://slurm.schedmd.com/
 .. _Kubernetes: https://kubernetes.io/
-.. _Deploying Dask: https://docs.dask.org/en/stable/deploying.html#distributed-computing
+.. _Deploying Dask: https://docs.dask.org/en/stable/deploying.html


### PR DESCRIPTION
The new version of github actions artifact handling requires uploads to be to unique names, this change handles that.