### PR TITLE
Drop support for k8s 1.24, test against 1.29

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -146,8 +146,6 @@ jobs:
         # k3s-channel: https://update.k3s.io/v1-release/channels
         #
         include:
-          - k3s-channel: v1.24
-            dask-namespace: default
           - k3s-channel: v1.25
             dask-namespace: separate-namespace
           - k3s-channel: v1.26
@@ -156,6 +154,8 @@ jobs:
           - k3s-channel: v1.27
             dask-namespace: default
           - k3s-channel: v1.28
+            dask-namespace: default
+          - k3s-channel: v1.29
             dask-namespace: default
 
     steps:

--- a/resources/helm/dask-gateway/Chart.yaml
+++ b/resources/helm/dask-gateway/Chart.yaml
@@ -8,4 +8,4 @@ home: https://gateway.dask.org/
 sources:
   - https://github.com/dask/dask-gateway/
 icon: https://avatars3.githubusercontent.com/u/17131925?v=3&s=200
-kubeVersion: ">=1.24.0-0"
+kubeVersion: ">=1.25.0-0"


### PR DESCRIPTION
k8s 1.24 has reached EOL for various cloud providers, so we drop support for it now and require k8s 1.25+.

This is related to https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/3309 that includes more details on cloud providers EOL for various k8s distributions.