### PR TITLE
Fix docs build by pinning indirect dependencies

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,7 +8,16 @@
 #
 dask-sphinx-theme>=3.0.5
 myst-parser
-sphinx
+
+# FIXME: This workaround is required until we have sphinx>=5, as enabled by
+#        dask-sphinx-theme no longer pinning sphinx-book-theme==0.2.0. This is
+#        tracked in https://github.com/dask/dask-sphinx-theme/issues/68.
+#
+sphinxcontrib-applehelp<1.0.5
+sphinxcontrib-devhelp<1.0.6
+sphinxcontrib-htmlhelp<2.0.5
+sphinxcontrib-serializinghtml<1.1.10
+sphinxcontrib-qthelp<1.0.7
 
 # sphinx-autobuild enables the "make devenv" command defined in the Makefile to
 # automatically rebuild the documentation on changes and update live-reload a


### PR DESCRIPTION
This can be reverted once a release of dask-sphinx-theme is out having resolved https://github.com/dask/dask-sphinx-theme/issues/68 so that we don't stay stuck at `sphinx<5`.