### PR TITLE
Require python 3.10+, up from 3.9+

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,14 +56,14 @@ jobs:
           #   we test integration with. We can test against only one version and
           #   that would be fine.
           #
-          - python-version: "3.9"
-            go-version: "1.20"
           - python-version: "3.10"
-            go-version: "1.21"
+            go-version: "1.20"
           - python-version: "3.11"
             go-version: "1.21"
           - python-version: "3.12"
-            go-version: "1.21"
+            go-version: "1.22"
+          - python-version: "3.13"
+            go-version: "1.23"
 
     steps:
       - uses: actions/checkout@v4

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     hooks:
       - id: pyupgrade
         args:
-          - --py39-plus
+          - --py310-plus
 
   # Autoformat: Python code
   - repo: https://github.com/PyCQA/isort

--- a/dask-gateway-server/setup.py
+++ b/dask-gateway-server/setup.py
@@ -255,7 +255,7 @@ setup(
     package_data=package_data,
     install_requires=install_requires,
     extras_require=extras_require,
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     entry_points={
         "console_scripts": [
             "dask-gateway-server = dask_gateway_server.app:main",

--- a/dask-gateway/setup.py
+++ b/dask-gateway/setup.py
@@ -48,6 +48,6 @@ setup(
     package_data={"dask_gateway": ["*.yaml"]},
     install_requires=install_requires,
     extras_require=extras_require,
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     zip_safe=False,
 )

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking changes
+
+- Requires Python 3.10+, up from 3.9
+
 ### 2024.1.0
 
 ([full changelog](https://github.com/dask/dask-gateway/compare/2023.9.0...2024.1.0))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,10 +13,10 @@ profile = "black"
 [tool.black]
 line-length = 88
 target_version = [
-    "py39",
     "py310",
     "py311",
     "py312",
+    "py313",
 ]
 
 


### PR DESCRIPTION
I see dask/distributed requires 3.10+, so I figure we should reduce the complexity of dask-gateway maintenance by requiring that as well.

I'm doing this now since I'm trying to debug issues in test failures (https://github.com/dask/dask-gateway/issues/814), removing py39 which needs to use an older distributed version could reduce some complexity.