### PR TITLE
helm-chart: require k8s 1.29+, up from 1.25+

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -146,16 +146,16 @@ jobs:
         # k3s-channel: https://update.k3s.io/v1-release/channels
         #
         include:
-          - k3s-channel: v1.25
+          - k3s-channel: v1.29
             dask-namespace: separate-namespace
-          - k3s-channel: v1.26
+          - k3s-channel: v1.30
             dask-namespace: default
             upgrade-from: "2022.4.0"
-          - k3s-channel: v1.27
+          - k3s-channel: v1.31
             dask-namespace: default
-          - k3s-channel: v1.28
+          - k3s-channel: v1.32
             dask-namespace: default
-          - k3s-channel: v1.29
+          - k3s-channel: stable
             dask-namespace: default
 
     steps:

--- a/docs/source/changelog.md
+++ b/docs/source/changelog.md
@@ -4,7 +4,8 @@
 
 ### Breaking changes
 
-- Requires Python 3.10+, up from 3.9
+- Requires Python 3.10+, up from 3.9+
+- Helm chart requires Kubernetes 1.29+, up from 1.25+
 
 ### 2024.1.0
 

--- a/resources/helm/dask-gateway/Chart.yaml
+++ b/resources/helm/dask-gateway/Chart.yaml
@@ -8,4 +8,4 @@ home: https://gateway.dask.org/
 sources:
   - https://github.com/dask/dask-gateway/
 icon: https://avatars3.githubusercontent.com/u/17131925?v=3&s=200
-kubeVersion: ">=1.25.0-0"
+kubeVersion: ">=1.29.0-0"


### PR DESCRIPTION
I'm adopting the same principle as in jupyterhub/zero-to-jupyterhub-k8s, which I think is reasonable - to drop support of k8s versions that are no longer supported by typical cloud providers like GCP/AWS/Azure. In January 2025, k8s 1.28 is too old for those cloud providers. See https://github.com/jupyterhub/zero-to-jupyterhub-k8s/issues/3510 for links with details about this.