### PR TITLE
helm-chart: remove use of deprecated traefik option

### DIFF
--- a/resources/helm/dask-gateway/templates/gateway/middleware.yaml
+++ b/resources/helm/dask-gateway/templates/gateway/middleware.yaml
@@ -20,5 +20,4 @@ spec:
   stripPrefix:
     prefixes:
       - '{{ .Values.gateway.prefix | trimSuffix "/" }}'
-    forceSlash: false
 {{- end }}


### PR DESCRIPTION
I meant to fix this warning seen in the traefik controller in k8s 1.32, but it seems that it causes a change to do so, so I'm closing this without further action for now - ideally we have a way to change this to retain current behavior while not getting warnings for something deprecated.

![image](https://github.com/user-attachments/assets/ecc0701d-4b87-490d-9138-bbf18bbb785c)
