### PR TITLE
helm-chart: remove deprecated use of traefik middleware's forceSlash option

### DIFF
--- a/resources/helm/dask-gateway/templates/gateway/middleware.yaml
+++ b/resources/helm/dask-gateway/templates/gateway/middleware.yaml
@@ -20,5 +20,4 @@ spec:
   stripPrefix:
     prefixes:
       - '{{ .Values.gateway.prefix | trimSuffix "/" }}'
-    forceSlash: false
 {{- end }}


### PR DESCRIPTION
forceSlash is deprecated by traefik.

I ran the tests on my github user and the k8s v1.32 tests passed. Ref https://github.com/gardleopard/dask-gateway/pull/1/checks . I guess pr #851 experienced flaky tests

closes #852 