### PR TITLE
update jupyterhub user url

### DIFF
--- a/dask-gateway-server/dask_gateway_server/auth.py
+++ b/dask-gateway-server/dask_gateway_server/auth.py
@@ -2,7 +2,6 @@ import base64
 import os
 import time
 import uuid
-from urllib.parse import quote
 
 import aiohttp
 from aiohttp import web
@@ -376,13 +375,10 @@ class JupyterHubAuthenticator(Authenticator):
         if token is None:
             raise unauthorized("jupyterhub")
 
-        url = "{}/authorizations/token/{}".format(
-            self.jupyterhub_api_url,
-            quote(token, safe=""),
-        )
+        url = f"{self.jupyterhub_api_url}/user"
 
         kwargs = {
-            "headers": {"Authorization": "token %s" % self.jupyterhub_api_token},
+            "headers": {"Authorization": f"token {token}"},
             "ssl": self.ssl_context,
         }
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -117,7 +117,7 @@ def configure_dask_gateway(jhub_api_token, jhub_bind_url):
         "dask_gateway_server.auth.JupyterHubAuthenticator"
     )
     config.JupyterHubAuthenticator.jupyterhub_api_token = jhub_api_token
-    config.JupyterHubAuthenticator.jupyterhub_api_url = jhub_bind_url + "api/"
+    config.JupyterHubAuthenticator.jupyterhub_api_url = jhub_bind_url + "api"
     return config
 
 


### PR DESCRIPTION
use standard `/api/user` instead

`/authorizations/token/{token}` is deprecated since jupyterhub 2.0 in 2021, superseded by `/api/user` in 0.8 in 2017.
