### PR TITLE
ci: use go 1.21 to build and publish dask-gateway-server to PyPI

### DIFF
--- a/.github/workflows/build-publish-python-packages.yaml
+++ b/.github/workflows/build-publish-python-packages.yaml
@@ -68,6 +68,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
+          go-version: "1.21"
           cache-dependency-path: "**/*.sum"
       - uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
I'm not sure if this caused a bug for the recent PyPI package, it could because of #848.