### PR TITLE
Fix typo in SLURM backend.

### DIFF
--- a/dask-gateway-server/dask_gateway_server/backends/jobqueue/slurm.py
+++ b/dask-gateway-server/dask_gateway_server/backends/jobqueue/slurm.py
@@ -61,7 +61,7 @@ class SlurmBackend(JobQueueBackend):
         if cluster.config.account:
             cmd.append("--account=" + cluster.config.account)
         if cluster.config.qos:
-            cmd.extend("--qos=" + cluster.config.qos)
+            cmd.append("--qos=" + cluster.config.qos)
 
         if worker:
             cpus = cluster.config.worker_cores


### PR DESCRIPTION
This typo prevents a cluster being created when a SLURM qos is set.

Like #603 but for qos instead. This list needs to be appended to instead of extended.

Apologies for not noticing this when I did #603 - we've just started using qos-s and ran into this immediately!