### PR TITLE
docs/ci: declare hadoop/yarn backend not supported, stop testing

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -313,7 +313,6 @@ jobs:
       fail-fast: false
       matrix:
         backend:
-          - hadoop
           - pbs
           - slurm
 

--- a/docs/source/api-server.rst
+++ b/docs/source/api-server.rst
@@ -82,12 +82,14 @@ YARN
 YarnClusterConfig
 ~~~~~~~~~~~~~~~~~
 
-.. autoconfigurable:: dask_gateway_server.backends.yarn.YarnClusterConfig
+YarnClusterConfig is as of 2026 longer supported, see
+https://github.com/dask/dask-gateway/issues/882 for some details.
 
 YarnBackend
 ~~~~~~~~~~~
 
-.. autoconfigurable:: dask_gateway_server.backends.yarn.YarnBackend
+YarnBackend is as of 2026 longer supported, see
+https://github.com/dask/dask-gateway/issues/882 for some details.
 
 
 Kubernetes

--- a/docs/source/develop.rst
+++ b/docs/source/develop.rst
@@ -140,7 +140,6 @@ run in docker (or in ``minikube`` for kubernetes). The scripts for setting up
 these test environments are located in the ``continuous_integration``
 subdirectory:
 
-- Hadoop Tests: ``continuous_integration/docker/hadoop``
 - PBS Tests: ``continuous_integration/docker/pbs``
 - Slurm Tests: ``continuous_integration/docker/slurm``
 - Kubernetes Tests: ``continuous_integration/kubernetes``

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -4,8 +4,8 @@ Dask Gateway
 Dask Gateway provides a secure, multi-tenant server for managing Dask_
 clusters.  It allows users to launch and use Dask clusters in a shared,
 centrally managed cluster environment, without requiring users to have direct
-access to the underlying cluster backend (e.g. Kubernetes, Hadoop/YARN, HPC Job
-queues, etc...).
+access to the underlying cluster backend (e.g. Kubernetes, HPC Job queues,
+etc...).
 
 Dask Gateway is one of many options for deploying Dask clusters, see `Deploying Dask`_ in the Dask documentation for an overview of additional options.
 
@@ -22,8 +22,8 @@ Highlights
   you to use what makes sense for your organization.
 
 - **Flexible**: The gateway is designed to support multiple backends, and runs
-  equally well in the cloud as on-premise. Natively supports Kubernetes,
-  Hadoop/YARN, and HPC Job Queueing systems.
+  equally well in the cloud as on-premise. Natively supports Kubernetes, and HPC
+  Job Queueing systems.
 
 - **Robust to Failure**: The gateway can be restarted or experience failover
   without losing existing clusters. Allows for seamless upgrades and restarts
@@ -54,9 +54,9 @@ both the cluster backend and the authentication protocol are pluggable.
 **Cluster Backends**
 
 - Kubernetes_
-- `Hadoop/YARN`_
 - Job Queue Systems (PBS_, Slurm_, ...)
 - Local Processes
+- `Hadoop/YARN`_ (Not supported since 2026)
 
 **Authentication Methods**
 

--- a/docs/source/install-hadoop.rst
+++ b/docs/source/install-hadoop.rst
@@ -1,5 +1,9 @@
-Install on a Hadoop Cluster
-===========================
+Install on a Hadoop Cluster (Not supported since 2026)
+======================================================
+
+Hadoop/YARN is as of 2026 no longer supported as a cluster backend for
+dask-gateway, as required dependencies no longer work with modern Python
+versions.
 
 Here we provide instructions for installing and configuring
 ``dask-gateway-server`` on a `Hadoop Cluster`_.


### PR DESCRIPTION
Based on https://github.com/dask/dask-gateway/issues/882, this documents hadoop/yarn to no longer be supported, and stops testing it.