### PR TITLE
ci: test Kerberos authenticator without Hadoop

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -334,3 +334,59 @@ jobs:
       - name: Print logs for debugging
         if: always()
         run: ./continuous_integration/docker/${{ matrix.backend }}/print_logs.sh
+
+  # This job tests the Kerberos authenticator against an ephemeral MIT
+  # Kerberos realm created with k5test directly on the runner, without needing
+  # a containerized backend.
+  #
+  # ref: https://github.com/dask/dask-gateway/issues/924
+  #
+  kerberos-tests:
+    name: "kerberos authentication"
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.25"
+          cache-dependency-path: "**/*.sum"
+
+      # krb5-kdc and krb5-admin-server provide the KDC that k5test manages,
+      # krb5-user provides kinit/klist, and libkrb5-dev with a compiler is
+      # needed to build pykerberos from source.
+      - name: Install Kerberos system dependencies
+        run: |
+          sudo apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y \
+              krb5-kdc \
+              krb5-admin-server \
+              krb5-user \
+              libkrb5-dev \
+              build-essential
+
+      - name: Install Python test requirements
+        run: |
+          pip install -r tests/requirements.txt
+          pip install k5test \
+              --editable="./dask-gateway[kerberos]" \
+              --editable="./dask-gateway-server[kerberos]"
+
+      - name: List Python dependencies
+        run: |
+          pip freeze
+
+      # With TEST_DASK_GATEWAY_KERBEROS set, test_kerberos_auth has no skip
+      # path, but verify the Kerberos test dependencies explicitly anyway so
+      # an installation problem is reported clearly.
+      - name: Verify Kerberos test dependencies
+        run: |
+          python -c "import kerberos, k5test"
+
+      - name: pytest
+        run: |
+          TEST_DASK_GATEWAY_KERBEROS=true pytest -v tests/test_auth.py -k kerberos

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -51,10 +51,11 @@ trustme
 #            For this to work, there needs to be various things running in the
 #            background.
 #
-# TEST_DASK_GATEWAY_YARN  - test_yarn_backend.py, and test_kerberos_auth in test_auth.py
-# TEST_DASK_GATEWAY_PBS   - test_pbs_backend.py
-# TEST_DASK_GATEWAY_SLURM - test_slurm_backend.py
-# TEST_DASK_GATEWAY_KUBE  - kubernetes/test_integration.py
+# TEST_DASK_GATEWAY_YARN     - test_yarn_backend.py
+# TEST_DASK_GATEWAY_PBS      - test_pbs_backend.py
+# TEST_DASK_GATEWAY_SLURM    - test_slurm_backend.py
+# TEST_DASK_GATEWAY_KUBE     - kubernetes/test_integration.py
+# TEST_DASK_GATEWAY_KERBEROS - test_kerberos_auth in test_auth.py
 #
 # TEST_DASK_GATEWAY_KUBE_ADDRESS is also used to describe how to reach the
 # traefik pod used as a proxy to access dask-gateway-server running in the api
@@ -63,10 +64,14 @@ trustme
 
 # IMPORTANT: Not installed Python packages with system dependencies
 #
-# - To run tests related to KerberosAuthenticator, you need to install
-#   pykerberos which is tricky to install with pip but easy with conda. For
-#   example, to install pykerberos with pip on ubunutu, you need to first
-#   install the apt package libkrb5-dev.
+# - To run test_kerberos_auth in test_auth.py, you need a Linux system with
+#   MIT Kerberos installed (on Ubuntu the apt packages krb5-kdc,
+#   krb5-admin-server, krb5-user, and libkrb5-dev), and the Python packages
+#   pykerberos (which needs libkrb5-dev and a compiler to build) and k5test.
+#   Then run:
+#
+#     TEST_DASK_GATEWAY_KERBEROS=true pytest -v tests/test_auth.py -k kerberos
+#
 # - To run tests related to JupyterHubAuthenticator, you need to install
 #   jupyterhub and the Node npm package configurable-http-proxy that JupyterHub
 #   depends on to route traffic.

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import subprocess
 import uuid
 
 import pytest
@@ -10,14 +9,15 @@ from traitlets.config import Config
 
 from .utils_test import temp_gateway
 
-try:
-    import kerberos
-
-    del kerberos
-    skip = not os.environ.get("TEST_DASK_GATEWAY_YARN")
-    requires_kerberos = pytest.mark.skipif(skip, reason="No kerberos server running")
-except ImportError:
-    requires_kerberos = pytest.mark.skipif(True, reason="Cannot import kerberos")
+# Testing the Kerberos authenticator requires a Linux system with MIT Kerberos
+# installed together with the pykerberos and k5test packages, so it is opt-in
+# via an environment variable. When TEST_DASK_GATEWAY_KERBEROS is set, missing
+# dependencies fail the test instead of skipping it, so CI can't silently pass
+# without testing the Kerberos authenticator.
+requires_kerberos = pytest.mark.skipif(
+    not os.environ.get("TEST_DASK_GATEWAY_KERBEROS"),
+    reason="TEST_DASK_GATEWAY_KERBEROS not set",
+)
 
 try:
     import jupyterhub.tests.mocking as hub_mocking
@@ -27,15 +27,28 @@ else:
     from tornado.log import access_log, app_log, gen_log
 
 
-KEYTAB_PATH = "/home/dask/dask.keytab"
+@pytest.fixture
+def kerberos_realm(monkeypatch):
+    """An ephemeral MIT Kerberos realm with a service principal for the gateway.
 
+    Creates a self-contained KDC with k5test, adds an HTTP service principal
+    matching the local hostname, and points the process environment at the
+    realm so that both the in-process gateway server and the client use it.
+    """
+    import k5test
 
-def kinit():
-    subprocess.check_call(["kinit", "-kt", KEYTAB_PATH, "dask"])
-
-
-def kdestroy():
-    subprocess.check_call(["kdestroy"])
+    realm = k5test.K5Realm(get_creds=False, create_host=False)
+    try:
+        http_princ = f"HTTP/{realm.hostname}@{realm.realm}"
+        realm.addprinc(http_princ)
+        realm.extract_keytab(http_princ, realm.keytab)
+        for key, value in realm.env.items():
+            monkeypatch.setenv(key, value)
+        yield realm
+    finally:
+        # Stops the KDC daemon and removes the realm's temporary directory
+        # (keytab, credential cache, database).
+        realm.stop()
 
 
 async def test_basic_auth():
@@ -63,26 +76,30 @@ async def test_basic_auth_password():
 
 
 @requires_kerberos
-async def test_kerberos_auth():
+async def test_kerberos_auth(kerberos_realm):
+    # The hostname in the gateway URL determines the service principal the
+    # client requests a ticket for, so the proxy must listen at the same
+    # hostname as the HTTP principal created by the kerberos_realm fixture.
     config = Config()
-    config.Proxy.address = "master.example.com:0"
+    config.Proxy.address = f"{kerberos_realm.hostname}:0"
     config.DaskGateway.authenticator_class = (
         "dask_gateway_server.auth.KerberosAuthenticator"
     )
-    config.KerberosAuthenticator.keytab = KEYTAB_PATH
+    config.KerberosAuthenticator.keytab = kerberos_realm.keytab
 
     async with temp_gateway(config=config) as g:
         async with g.gateway_client(auth="kerberos") as gateway:
-            kdestroy()
-
+            # The realm is created without credentials, so requests fail
             with pytest.raises(Exception):
                 await gateway.list_clusters()
 
-            kinit()
+            # After kinit the full mutual authentication handshake succeeds
+            kerberos_realm.kinit(
+                kerberos_realm.user_princ,
+                password=kerberos_realm.password("user"),
+            )
 
             await gateway.list_clusters()
-
-            kdestroy()
 
 
 class temp_hub:


### PR DESCRIPTION
Closes #924

We use dask-gateway with Kerberos authentication at my company, so I decided
to try bringing this test coverage back.

Since #923 removed the Hadoop/YARN backend from CI, `test_kerberos_auth` has
been skipped unconditionally: it was gated on `TEST_DASK_GATEWAY_YARN` and
relied on the KDC, hostname and keytab of the old Hadoop container.

This PR restores real CI coverage of the Kerberos authenticator without
bringing back the unsupported Hadoop/YARN image:

- The test now creates its own ephemeral MIT Kerberos realm with
  [k5test](https://pypi.org/project/k5test/) (a small test-only library from
  the python-gssapi org), so no external KDC is needed. It is gated on a new
  `TEST_DASK_GATEWAY_KERBEROS` env var, and when that is set there is no
  skip path — missing dependencies fail the job instead of silently
  skipping the test.
- A new `kerberos-tests` CI job installs MIT Kerberos from apt, builds
  pykerberos via the `[kerberos]` extras, and runs the test (~2 minutes).
- Comments in `tests/requirements.txt` updated to match.

No production code changes.

Some verification beyond CI being green here:

- 30 back-to-back runs in a clean Ubuntu 24.04 container, no flakiness.
- Breaking the `HTTP/<hostname>` service principal on purpose makes the test
  fail with "Server not found in Kerberos database", so the test really
  exercises the handshake and can't pass by accident.
- The kerberos job passed 3/3 times on GitHub-hosted runners in my fork.
- Without kerberos packages and the env var the test still skips cleanly, so
  the regular test matrix is unaffected.

Unrelated notes:

- The `local backend` and `pbs`/`slurm backend` jobs currently fail on
  `main` for reasons unrelated to this PR (missing `dask-scheduler` CLI with
  latest distributed; pillow sdist build without gcc in the CI containers).
  Happy to open separate issues for those.
- `continuous_integration/docker/hadoop/` is orphaned since #923 and could
  be removed in a follow-up.
